### PR TITLE
Bump to pom-imagej 2.15 to get a newer version of scripting-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>net.imagej</groupId>
 		<artifactId>pom-imagej</artifactId>
-		<version>2.13</version>
+		<version>2.15</version>
 		<relativePath />
 	</parent>
 


### PR DESCRIPTION
This is needed to support developing .java plugins in the script editor,
as scripting-java and MiniMaven got bug fixes for that use case in the
meantime. The updated versions are already referenced in a new
pom-scijava, but pom-imagej was not yet updated accordingly (waiting for
the very topic branches in imagej-ui-swing and imagej-legacy for which
the bug fixes were developed).

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
