### PR TITLE
Let's call it the ImageJ Wiki in the ImageJ updater

### DIFF
--- a/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
+++ b/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
@@ -501,7 +501,7 @@ public class SitesDialog extends JDialog implements ActionListener {
 					"<h2>Personal update site setup</h2>" +
 					"<p width=400>For security reasons, personal update sites are associated with a ImageJ Wiki account. " +
 					"Please provide the account name of your ImageJ Wiki account.</p>" +
-					"<p width=400>If your personal udate site was not yet initialized, you can initialize it in this dialog.</p>" +
+					"<p width=400>If your personal update site was not yet initialized, you can initialize it in this dialog.</p>" +
 					"<p width=400>You can register a ImageJ Wiki account here if  you do not have one yet.</p></html>"), "span 2");
 			userLabel = new JLabel("ImageJ Wiki account");
 			add(userLabel);


### PR DESCRIPTION
It is really funny how some people still think that Fiji is something
completely different than ImageJ. Granted, the name is different, but
we were asked specifically not to use the same name. Oh well, history.

Anyway, the ImageJ Wiki -- http://wiki.imagej.net/ -- is just another
skin and default page for the Fiji Wiki, to reflect the nature of the
true relationship between the Fiji and the ImageJ2 project: very,
very collaborative and collegial.

So let's just tell the ImageJ updater users that they are about to
get an ImageJ Wiki account for the to-be-initialized personal update
site.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
