### PR TITLE
Update rsyntaxtextarea to version 2.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 		<dependency>
 			<groupId>com.fifesoft</groupId>
 			<artifactId>rsyntaxtextarea</artifactId>
-			<version>2.5.0</version>
+			<version>2.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.miglayout</groupId>

--- a/src/main/java/net/imagej/ui/swing/script/FindAndReplaceDialog.java
+++ b/src/main/java/net/imagej/ui/swing/script/FindAndReplaceDialog.java
@@ -197,7 +197,7 @@ public class FindAndReplaceDialog extends JDialog implements ActionListener {
 		else if (source == replace)
 			searchOrReplace(true);
 		else if (source == replaceAll) {
-			int replace = SearchEngine.replaceAll(getTextArea(), getSearchContext(true));
+			int replace = SearchEngine.replaceAll(getTextArea(), getSearchContext(true)).getMarkedCount();
 			JOptionPane.showMessageDialog(this, replace
 					+ " replacements made!");
 		}
@@ -239,9 +239,9 @@ public class FindAndReplaceDialog extends JDialog implements ActionListener {
 	protected boolean searchOrReplaceFromHere(boolean replace, boolean forward) {
 		RSyntaxTextArea textArea = getTextArea();
 		SearchContext context = getSearchContext(forward);
-		return replace ?
+		return (replace ?
 			SearchEngine.replace(textArea, context) :
-			SearchEngine.find(textArea, context);
+			SearchEngine.find(textArea, context)).wasFound();
 	}
 
 	public boolean isReplace() {

--- a/src/main/java/net/imagej/ui/swing/script/TokenFunctions.java
+++ b/src/main/java/net/imagej/ui/swing/script/TokenFunctions.java
@@ -58,36 +58,23 @@ public class TokenFunctions implements Iterable<Token> {
 	}
 
 	public static boolean tokenEquals(Token token, char[] text) {
-		if (token.getType() != TokenTypes.RESERVED_WORD ||
-				token.length() != text.length)
-			return false;
-		final char[] tokenText = token.getTextArray();
-		if (tokenText == null) return false;
-		final int textOffset = token.getTextOffset();
-		for (int i = 0; i < text.length; i++)
-			if (tokenText[textOffset + i] != text[i])
-				return false;
-		return true;
+		return token.is(TokenTypes.RESERVED_WORD, text);
 	}
 
 	public static boolean isIdentifier(Token token) {
 		if (token.getType() != TokenTypes.IDENTIFIER)
 			return false;
-		final char[] tokenText = token.getTextArray();
-		final int textOffset = token.getTextOffset();
-		if (tokenText == null || !Character.isJavaIdentifierStart(tokenText[textOffset]))
+		final char[] tokenText = token.getLexeme().toCharArray();
+		if (tokenText == null || !Character.isJavaIdentifierStart(tokenText[0]))
 			return false;
 		for (int i = 1; i < tokenText.length; i++)
-			if (!Character.isJavaIdentifierPart(tokenText[textOffset + i]))
+			if (!Character.isJavaIdentifierPart(tokenText[i]))
 				return false;
 		return true;
 	}
 
 	public static String getText(Token token) {
-		final char[] tokenText = token.getTextArray();
-		if (tokenText == null)
-			return "";
-		return new String(tokenText, token.getTextOffset(), token.length());
+		return token.getLexeme();
 	}
 
 	public void replaceToken(Token token, String text) {
@@ -140,16 +127,13 @@ public class TokenFunctions implements Iterable<Token> {
 	}
 
 	public static boolean isDot(Token token) {
-		if (token.getType() != TokenTypes.IDENTIFIER) return false;
-		final char[] tokenText = token.getTextArray();
-		return tokenText != null && token.length() == 1 && tokenText[token.getTextOffset()] == '.';
+		return token.is(TokenTypes.IDENTIFIER, ".");
 	}
 
 	/* The following methods are Java-specific */
 
-	public final static char[] classCharacters = {'c', 'l', 'a', 's', 's'};
 	public static boolean isClass(Token token) {
-		return tokenEquals(token, classCharacters);
+		return token.is(TokenTypes.RESERVED_WORD, "class");
 	}
 
 	public String getClassName() {


### PR DESCRIPTION
(Until version 2.5.2 of RSyntaxTextArea is available on maven.imagej.net, this request should be ignored. :-) )

In the hopes of improving compatibility with Micro-Manager, as well as keeping dependencies up to date, I've created this patch series to update imagej-ui-swing to the second-latest version of the RSyntaxTextArea API. (2.5.3 was released on 30 June.)

The first patch is just a fixup to catch some missed token instance -> TokenType references. The next changes the version in the POM. The remaining three are minor fixes to API (probably they could've been rolled into one patch, but this works).
