### PR TITLE
Scroll list of update sites to bottom when a new site is added

### DIFF
--- a/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
+++ b/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
@@ -76,6 +76,8 @@ import net.imagej.updater.util.UpdaterUtil;
 import net.imagej.util.MediaWikiClient;
 import net.miginfocom.swing.MigLayout;
 
+import org.scijava.ui.swing.StaticSwingUtils;
+
 /**
  * The dialog in which the user can choose which update sites to follow.
  * 
@@ -301,6 +303,7 @@ public class SitesDialog extends JDialog implements ActionListener {
 		tableModel.rowsChanged();
 		tableModel.rowChanged(row);
 		table.setRowSelectionInterval(row, row);
+		StaticSwingUtils.scrollToBottom(scrollpane);
 	}
 
 	private String makeUniqueSiteName(final String prefix) {

--- a/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
+++ b/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
@@ -90,6 +90,7 @@ public class SitesDialog extends JDialog implements ActionListener {
 
 	protected DataModel tableModel;
 	protected JTable table;
+	protected JScrollPane scrollpane;
 	protected JButton addNewSite, addPersonalSite, remove, close;
 
 	public SitesDialog(final UpdaterFrame owner, final FilesCollection files)
@@ -243,7 +244,7 @@ public class SitesDialog extends JDialog implements ActionListener {
 		table.setRowSelectionAllowed(true);
 		table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 		tableModel.setColumnWidths();
-		final JScrollPane scrollpane = new JScrollPane(table);
+		scrollpane = new JScrollPane(table);
 		scrollpane.setPreferredSize(new Dimension(tableModel.tableWidth, 400));
 		contentPane.add(scrollpane);
 


### PR DESCRIPTION
In line with [previous discussions](http://fiji.sc/bugzilla/show_bug.cgi?id=1041), here's a small enhancement that scrolls down the update sites dialog whenever a new site is added.

This depends on `StaticSwingUtils.scrollToBottom(JScrollPane pane)` introduced in `scijava-ui-swing` [`a6d8604`](https://github.com/scijava/scijava-ui-swing/commit/a6d860470addb48e92b9baafddbc9c8523c417f4)