### PR TITLE
Clearer text for the updater "Add" button

### DIFF
--- a/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
+++ b/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
@@ -252,7 +252,7 @@ public class SitesDialog extends JDialog implements ActionListener {
 
 		final JPanel buttons = new JPanel();
 		addPersonalSite = SwingTools.button("Add my site", "Add my personal update site", this, buttons);
-		addNewSite = SwingTools.button("Add", "Add", this, buttons);
+		addNewSite = SwingTools.button("Add update site", "Add update site", this, buttons);
 		remove = SwingTools.button("Remove", "Remove", this, buttons);
 		remove.setEnabled(false);
 		close = SwingTools.button("Close", "Close", this, buttons);


### PR DESCRIPTION
Manually adding a new update site (adding to receive updates, not when setting up a new one for upload to the ImageJ servers) seems to be confusing to users. More than once have people complained to me because when I tell them to add a new site they incorrectly click on "Add my site". The buttons seem clear to me but this may be because of my familiarity with it.

I believe the problem is that "Add" is not clear enough so I changed it "Add update site". I also think that the "Add my site" button is misleading. The button is to 1) add a site hosted by ImageJ servers and 2) when the person is also interested on making the uploads via that installation of Fiji. However, I couldn't think of any better wording that would be fit for a button so I left it as it was.

It has also occurred to me that part of the issue could be the order of the buttons but I'm not a UI designer to judge that well. The new wording I'm proposing also makes the button larger, with the same length as the "Add my site", which to me eye seems to help.

![updater-screenshot](https://cloud.githubusercontent.com/assets/916140/7667307/07124b5e-fbfb-11e4-8593-b039afdeba07.jpg)
