### PR TITLE
Cleanup Script Editor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 		<dependency>
 			<groupId>com.fifesoft</groupId>
 			<artifactId>rsyntaxtextarea</artifactId>
-			<version>2.5.6</version>
+			<version>2.5.7</version>
 		</dependency>
 		<dependency>
 			<groupId>com.miglayout</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,6 @@
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-ui-swing</artifactId>
-			<version>0.6.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>

--- a/src/main/java/net/imagej/ui/swing/script/Bookmark.java
+++ b/src/main/java/net/imagej/ui/swing/script/Bookmark.java
@@ -1,0 +1,42 @@
+
+package net.imagej.ui.swing.script;
+
+import javax.swing.text.BadLocationException;
+
+import org.fife.ui.rtextarea.GutterIconInfo;
+
+/**
+ * A "bookmark" is a stored location (line, file) in the text editor.
+ * 
+ * @author Johannes Schindelin
+ * @author Jonathan Hale
+ */
+public class Bookmark {
+
+	TextEditorTab tab;
+	GutterIconInfo info;
+
+	public Bookmark(final TextEditorTab tab, final GutterIconInfo info) {
+		this.tab = tab;
+		this.info = info;
+	}
+
+	public int getLineNumber() {
+		try {
+			return tab.editorPane.getLineOfOffset(info.getMarkedOffset());
+		}
+		catch (final BadLocationException e) {
+			return -1;
+		}
+	}
+
+	public void setCaret() {
+		tab.requestFocus();
+		tab.editorPane.setCaretPosition(info.getMarkedOffset());
+	}
+
+	@Override
+	public String toString() {
+		return "Line " + (getLineNumber() + 1) + " (" + tab.editorPane.getFileName() + ")";
+	}
+}

--- a/src/main/java/net/imagej/ui/swing/script/BookmarkDialog.java
+++ b/src/main/java/net/imagej/ui/swing/script/BookmarkDialog.java
@@ -57,7 +57,7 @@ public class BookmarkDialog extends JDialog implements ActionListener {
 	JList list;
 	JButton okay, cancel;
 
-	public BookmarkDialog(final Frame owner, final Vector<EditorPane.Bookmark> bookmarks) {
+	public BookmarkDialog(final Frame owner, final Vector<Bookmark> bookmarks) {
 		super(owner, "Bookmarks", true);
 
 		getContentPane().setLayout(new BoxLayout(getContentPane(), BoxLayout.Y_AXIS));
@@ -105,7 +105,7 @@ public class BookmarkDialog extends JDialog implements ActionListener {
 	}
 
 	public boolean jumpToSelectedBookmark() {
-		EditorPane.Bookmark bookmark = (EditorPane.Bookmark)list.getSelectedValue();
+		Bookmark bookmark = (Bookmark)list.getSelectedValue();
 		if (bookmark == null)
 			return false;
 		bookmark.setCaret();

--- a/src/main/java/net/imagej/ui/swing/script/EditorPane.java
+++ b/src/main/java/net/imagej/ui/swing/script/EditorPane.java
@@ -81,8 +81,6 @@ import org.scijava.util.FileUtils;
  */
 public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 
-	private final TextEditor frame;
-
 	private String fallBackBaseName;
 	private File curFile;
 	private File gitDirectory;
@@ -104,17 +102,8 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 
 	/**
 	 * Constructor.
-	 *
-	 * @param frame TextEditor this {@link EditorPane} should belong to. Never
-	 *          <code>null</code>.
 	 */
-	public EditorPane(final TextEditor frame) {
-		if (frame == null) {
-			throw new IllegalArgumentException("frame cannot be null");
-		}
-
-		this.frame = frame;
-
+	public EditorPane() {
 		setLineWrap(false);
 		setTabSize(8);
 

--- a/src/main/java/net/imagej/ui/swing/script/EditorPane.java
+++ b/src/main/java/net/imagej/ui/swing/script/EditorPane.java
@@ -67,6 +67,7 @@ import org.fife.ui.rtextarea.RTextArea;
 import org.fife.ui.rtextarea.RTextScrollPane;
 import org.fife.ui.rtextarea.RecordableTextAction;
 import org.scijava.plugin.Parameter;
+import org.scijava.prefs.PrefService;
 import org.scijava.script.ScriptHeaderService;
 import org.scijava.script.ScriptLanguage;
 import org.scijava.util.FileUtils;
@@ -80,7 +81,7 @@ import org.scijava.util.FileUtils;
  */
 public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 
-	private TextEditor frame;
+	private final TextEditor frame;
 	private String fallBackBaseName;
 	private File curFile;
 	private File gitDirectory;
@@ -93,6 +94,8 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 
 	@Parameter
 	private ScriptHeaderService scriptHeaderService;
+	@Parameter
+	private PrefService prefService;
 
 	/**
 	 * Constructor.
@@ -587,4 +590,41 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 			endAtomicEdit();
 		}
 	}
+
+	// --- Preferences ---
+	public static final String FONT_SIZE_PREFS = "script.editor.FontSize";
+	public static final String LINE_WRAP_PREFS = "script.editor.WrapLines";
+	public static final String TAB_SIZE_PREFS = "script.editor.TabSize";
+	public static final String TABS_EMULATED_PREFS = "script.editor.TabsEmulated";
+
+	public static final int DEFAULT_TAB_SIZE = 4;
+
+	/**
+	 * Loads the preferences for the Tab and apply them.
+	 */
+	public void loadPreferences() {
+		resetTabSize();
+		setFontSize(prefService.getFloat(FONT_SIZE_PREFS, getFontSize()));
+		setLineWrap(prefService.getBoolean(LINE_WRAP_PREFS, getLineWrap()));
+		setTabsEmulated(prefService.getBoolean(TABS_EMULATED_PREFS,
+			getTabsEmulated()));
+	}
+
+	/**
+	 * Retrieves and saves the preferences to the persistent store
+	 */
+	public void savePreferences() {
+		prefService.put(TAB_SIZE_PREFS, getTabSize());
+		prefService.put(FONT_SIZE_PREFS, getFontSize());
+		prefService.put(LINE_WRAP_PREFS, getLineWrap());
+		prefService.put(TABS_EMULATED_PREFS, getTabsEmulated());
+	}
+
+	/**
+	 * Reset tab size to current preferences.
+	 */
+	public void resetTabSize() {
+		setTabSize(prefService.getInt(TAB_SIZE_PREFS, DEFAULT_TAB_SIZE));
+	}
+
 }

--- a/src/main/java/net/imagej/ui/swing/script/EditorPane.java
+++ b/src/main/java/net/imagej/ui/swing/script/EditorPane.java
@@ -45,12 +45,10 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.util.Collection;
-import java.util.EventListener;
 import java.util.List;
 
 import javax.swing.JScrollPane;
 import javax.swing.JViewport;
-import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
@@ -371,22 +369,12 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	 */
 	public void setFileName(final File file) {
 		curFile = file;
-		updateGitDirectory();
 
 		if (file != null) {
 			setLanguageByFileName(file.getName());
 			fallBackBaseName = null;
 		}
 		fileLastModified = file == null || !file.exists() ? 0 : file.lastModified();
-	}
-
-	/**
-	 * Update the git directory to the git directory of the current file.
-	 * 
-	 * @see #getGitDirectory()
-	 */
-	protected void updateGitDirectory() {
-		gitDirectory = new FileFunctions(frame).getGitDirectory(curFile);
 	}
 
 	/**
@@ -397,6 +385,15 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	 */
 	public File getGitDirectory() {
 		return gitDirectory;
+	}
+
+	/**
+	 * Set this {@link EditorPane}s git directory.
+	 * 
+	 * @param dir directory to set the git directory to.
+	 */
+	public void setGitDirectory(File dir) {
+		gitDirectory = dir;
 	}
 
 	/**
@@ -475,7 +472,6 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 			if (!defaultExtension.equals(ext)) {
 				name = name.substring(0, name.length() - ext.length());
 				curFile = new File(curFile.getParentFile(), name + defaultExtension);
-				updateGitDirectory();
 				modifyCount = Integer.MIN_VALUE;
 			}
 		}

--- a/src/main/java/net/imagej/ui/swing/script/EditorPane.java
+++ b/src/main/java/net/imagej/ui/swing/script/EditorPane.java
@@ -44,6 +44,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.util.Collection;
 import java.util.List;
 import java.util.Vector;
 
@@ -477,9 +478,15 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		}
 	}
 
-	public void getBookmarks(int tab, Vector<Bookmark> result) {
-		if (gutter == null)
-			return;
+	/**
+	 * Add this editors bookmarks to the specified collection.
+	 * 
+	 * @param tab Tab index to set for added bookmarks.
+	 * @param result Collection to add the bookmarks to.
+	 */
+	public void getBookmarks(final int tab, final Collection<Bookmark> result) {
+		if (gutter == null) return;
+
 		for (GutterIconInfo info : gutter.getBookmarks())
 			result.add(new Bookmark(tab, info));
 	}

--- a/src/main/java/net/imagej/ui/swing/script/EditorPane.java
+++ b/src/main/java/net/imagej/ui/swing/script/EditorPane.java
@@ -75,6 +75,7 @@ import org.scijava.util.FileUtils;
  * TODO
  * 
  * @author Johannes Schindelin
+ * @author Jonathan Hale
  */
 public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	TextEditor frame;
@@ -483,24 +484,34 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 			result.add(new Bookmark(tab, info));
 	}
 
-	/** Adapted from ij.plugin.frame.Editor */
+	/**
+	 * Adapted from ij.plugin.frame.Editor. Replaces unquoted invalid ascii
+	 * characters with spaces. Characters are considered invalid if outside the
+	 * range of [32, 127] (except newlines and vertical tabs).
+	 * 
+	 * @return number of characters replaced.
+	 */
 	public int zapGremlins() {
 		final char[] chars = getText().toCharArray();
-		int count=0;
+		int count = 0; // number of "gremlins" zapped
 		boolean inQuotes = false;
 		char quoteChar = 0;
-		for (int i=0; i<chars.length; i++) {
-			char c = chars[i];
-			if (!inQuotes && (c=='"' || c=='\'')) {
-				inQuotes = true;
-				quoteChar = c;
-			} else  {
-				if (inQuotes && (c==quoteChar || c=='\n'))
-				inQuotes = false;
+
+		for (int i = 0; i < chars.length; ++i) {
+			final char c = chars[i];
+
+			if (!inQuotes) {
+				if (c == '"' || c == '\'') {
+					inQuotes = true;
+					quoteChar = c;
+				}
+				else if (c != '\n' && c != '\t' && (c < 32 || c > 127)) {
+					count++;
+					chars[i] = ' ';
+				}
 			}
-			if (!inQuotes && c!='\n' && c!='\t' && (c<32||c>127)) {
-				count++;
-				chars[i] = ' ';
+			else if (c == quoteChar || c == '\n') {
+				inQuotes = false;
 			}
 		}
 		if (count>0) {

--- a/src/main/java/net/imagej/ui/swing/script/EditorPane.java
+++ b/src/main/java/net/imagej/ui/swing/script/EditorPane.java
@@ -72,23 +72,24 @@ import org.scijava.script.ScriptLanguage;
 import org.scijava.util.FileUtils;
 
 /**
- * TODO
+ * Main text editing component of the script editor, based on
+ * {@link RSyntaxTextArea}.
  * 
  * @author Johannes Schindelin
  * @author Jonathan Hale
  */
 public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 
-	TextEditor frame;
-	String fallBackBaseName;
-	File curFile;
-	File gitDirectory;
-	long fileLastModified;
-	ScriptLanguage currentLanguage;
-	Gutter gutter;
-	IconGroup iconGroup;
-	int modifyCount;
-	boolean undoInProgress, redoInProgress;
+	private TextEditor frame;
+	private String fallBackBaseName;
+	private File curFile;
+	private File gitDirectory;
+	private long fileLastModified;
+	private ScriptLanguage currentLanguage;
+	private Gutter gutter;
+	private IconGroup iconGroup;
+	private int modifyCount;
+	private boolean undoInProgress, redoInProgress;
 
 	@Parameter
 	private ScriptHeaderService scriptHeaderService;
@@ -105,7 +106,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		}
 
 		this.frame = frame;
-		
+
 		setLineWrap(false);
 		setTabSize(8);
 		getActionMap()
@@ -234,7 +235,8 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	}
 
 	public boolean wasChangedOutside() {
-		return curFile != null && curFile.exists() && curFile.lastModified() != fileLastModified;
+		return curFile != null && curFile.exists() &&
+			curFile.lastModified() != fileLastModified;
 	}
 
 	public void write(File file) throws IOException {
@@ -404,6 +406,24 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		if (header != null) {
 			setText(header += getText());
 		}
+	}
+
+	/**
+	 * Get file currently open in this {@link EditorPane}.
+	 * 
+	 * @return the file.
+	 */
+	public File getFile() {
+		return curFile;
+	}
+
+	/**
+	 * Get {@link ScriptLanguage} used for this {@link EditorPane}.
+	 * 
+	 * @return current {@link ScriptLanguage}.
+	 */
+	public ScriptLanguage getCurrentLanguage() {
+		return currentLanguage;
 	}
 
 	public float getFontSize() {

--- a/src/main/java/net/imagej/ui/swing/script/EditorPane.java
+++ b/src/main/java/net/imagej/ui/swing/script/EditorPane.java
@@ -46,7 +46,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.util.Collection;
 import java.util.List;
-import java.util.Vector;
 
 import javax.swing.JScrollPane;
 import javax.swing.JViewport;
@@ -79,6 +78,7 @@ import org.scijava.util.FileUtils;
  * @author Jonathan Hale
  */
 public class EditorPane extends RSyntaxTextArea implements DocumentListener {
+
 	TextEditor frame;
 	String fallBackBaseName;
 	File file, gitDirectory;
@@ -96,22 +96,21 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		this.frame = frame;
 		setLineWrap(false);
 		setTabSize(8);
-		getActionMap().put(DefaultEditorKit
-				.nextWordAction, wordMovement(+1, false));
-		getActionMap().put(DefaultEditorKit
-				.selectionNextWordAction, wordMovement(+1, true));
-		getActionMap().put(DefaultEditorKit
-				.previousWordAction, wordMovement(-1, false));
-		getActionMap().put(DefaultEditorKit
-				.selectionPreviousWordAction, wordMovement(-1, true));
+		getActionMap()
+			.put(DefaultEditorKit.nextWordAction, wordMovement(+1, false));
+		getActionMap().put(DefaultEditorKit.selectionNextWordAction,
+			wordMovement(+1, true));
+		getActionMap().put(DefaultEditorKit.previousWordAction,
+			wordMovement(-1, false));
+		getActionMap().put(DefaultEditorKit.selectionPreviousWordAction,
+			wordMovement(-1, true));
 		ToolTipManager.sharedInstance().registerComponent(this);
 		getDocument().addDocumentListener(this);
 	}
 
 	@Override
 	public void setTabSize(int width) {
-		if (getTabSize() != width)
-			super.setTabSize(width);
+		if (getTabSize() != width) super.setTabSize(width);
 	}
 
 	public void embedWithScrollbars(Container container) {
@@ -129,24 +128,20 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		return sp;
 	}
 
-	RecordableTextAction wordMovement(final int direction,
-			final boolean select) {
+	RecordableTextAction wordMovement(final int direction, final boolean select) {
 		final String id = "WORD_MOVEMENT_" + select + direction;
 		return new RecordableTextAction(id) {
+
 			@Override
-			public void actionPerformedImpl(ActionEvent e,
-					RTextArea textArea) {
+			public void actionPerformedImpl(ActionEvent e, RTextArea textArea) {
 				int pos = textArea.getCaretPosition();
-				int end = direction < 0 ? 0 :
-					textArea.getDocument().getLength();
+				int end = direction < 0 ? 0 : textArea.getDocument().getLength();
 				while (pos != end && !isWordChar(textArea, pos))
 					pos += direction;
 				while (pos != end && isWordChar(textArea, pos))
 					pos += direction;
-				if (select)
-					textArea.moveCaretPosition(pos);
-				else
-					textArea.setCaretPosition(pos);
+				if (select) textArea.moveCaretPosition(pos);
+				else textArea.setCaretPosition(pos);
 			}
 
 			@Override
@@ -156,15 +151,12 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 
 			boolean isWordChar(RTextArea textArea, int pos) {
 				try {
-					char c = textArea.getText(pos
-						+ (direction < 0 ? -1 : 0), 1)
-						.charAt(0);
-					return c > 0x7f ||
-						(c >= 'A' && c <= 'Z') ||
-						(c >= 'a' && c <= 'z') ||
-						(c >= '0' && c <= '9') ||
-						c == '_';
-				} catch (BadLocationException e) {
+					char c =
+						textArea.getText(pos + (direction < 0 ? -1 : 0), 1).charAt(0);
+					return c > 0x7f || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+						(c >= '0' && c <= '9') || c == '_';
+				}
+				catch (BadLocationException e) {
 					return false;
 				}
 			}
@@ -201,42 +193,40 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 
 	// triggered only by syntax highlighting
 	@Override
-	public void changedUpdate(DocumentEvent e) { }
+	public void changedUpdate(DocumentEvent e) {}
 
 	protected void modified() {
 		checkForOutsideChanges();
 		boolean update = modifyCount == 0;
-		if (undoInProgress)
-			modifyCount--;
-		else if (redoInProgress || modifyCount >= 0)
-			modifyCount++;
+		if (undoInProgress) modifyCount--;
+		else if (redoInProgress || modifyCount >= 0) modifyCount++;
 		else // not possible to get back to clean state
-			modifyCount = Integer.MIN_VALUE;
-		if (update || modifyCount == 0)
-			setTitle();
+		modifyCount = Integer.MIN_VALUE;
+		if (update || modifyCount == 0) setTitle();
 	}
 
 	public boolean isNew() {
-		return !fileChanged() && file == null &&
-			fallBackBaseName == null &&
+		return !fileChanged() && file == null && fallBackBaseName == null &&
 			getDocument().getLength() == 0;
 	}
 
 	public void checkForOutsideChanges() {
-		if (frame != null && wasChangedOutside() &&
-				!frame.reload("The file " + file.getName()
-					+ " was changed outside of the editor"))
-			fileLastModified = file.lastModified();
+		if (frame != null &&
+			wasChangedOutside() &&
+			!frame.reload("The file " + file.getName() +
+				" was changed outside of the editor")) fileLastModified =
+			file.lastModified();
 	}
 
 	public boolean wasChangedOutside() {
 		return file != null && file.exists() &&
-				file.lastModified() != fileLastModified;
+			file.lastModified() != fileLastModified;
 	}
 
 	public void write(File file) throws IOException {
 		BufferedWriter outFile =
-			new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"));
+			new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file),
+				"UTF-8"));
 		outFile.write(getText());
 		outFile.close();
 		modifyCount = 0;
@@ -250,36 +240,37 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		else {
 			int line = 0;
 			try {
-				if (file.getCanonicalPath().equals(oldFile.getCanonicalPath()))
-					line = getCaretLineNumber();
-			} catch (Exception e) { /* ignore */ }
+				if (file.getCanonicalPath().equals(oldFile.getCanonicalPath())) line =
+					getCaretLineNumber();
+			}
+			catch (Exception e) { /* ignore */}
 			if (!file.exists()) {
 				modifyCount = Integer.MIN_VALUE;
 				setFileName(file);
 				return;
 			}
 			StringBuffer string = new StringBuffer();
-			BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+			BufferedReader reader =
+				new BufferedReader(new InputStreamReader(new FileInputStream(file),
+					"UTF-8"));
 			char[] buffer = new char[16384];
 			for (;;) {
 				int count = reader.read(buffer);
-				if (count < 0)
-					break;
+				if (count < 0) break;
 				string.append(buffer, 0, count);
 			}
 			reader.close();
 			setText(string.toString());
 			this.file = file;
-			if (line > getLineCount())
-				line = getLineCount() - 1;
+			if (line > getLineCount()) line = getLineCount() - 1;
 			try {
 				setCaretPosition(getLineStartOffset(line));
-			} catch (BadLocationException e) { /* ignore */ }
+			}
+			catch (BadLocationException e) { /* ignore */}
 		}
 		discardAllEdits();
 		modifyCount = 0;
-		fileLastModified = file == null || !file.exists() ? 0 :
-			file.lastModified();
+		fileLastModified = file == null || !file.exists() ? 0 : file.lastModified();
 	}
 
 	public void setFileName(String baseName) {
@@ -291,14 +282,13 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		for (String extension : currentLanguage.getExtensions()) {
 			extension = "." + extension;
 			if (baseName.endsWith(extension)) {
-				name = name.substring(0, name.length()
-						- extension.length());
+				name = name.substring(0, name.length() - extension.length());
 				break;
 			}
 		}
 		fallBackBaseName = name;
-		if (currentLanguage.getLanguageName().equals("Java"))
-			new TokenFunctions(this).setClassName(name);
+		if (currentLanguage.getLanguageName().equals("Java")) new TokenFunctions(
+			this).setClassName(name);
 	}
 
 	public void setFileName(final File file) {
@@ -307,6 +297,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		setTitle();
 		if (file != null) {
 			SwingUtilities.invokeLater(new Thread() {
+
 				@Override
 				public void run() {
 					setLanguageByFileName(file.getName());
@@ -314,8 +305,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 			});
 			fallBackBaseName = null;
 		}
-		fileLastModified = file == null || !file.exists() ? 0 :
-			file.lastModified();
+		fileLastModified = file == null || !file.exists() ? 0 : file.lastModified();
 	}
 
 	protected void updateGitDirectory() {
@@ -327,8 +317,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	}
 
 	protected String getFileName() {
-		if (file != null)
-			return file.getName();
+		if (file != null) return file.getName();
 		String extension = "";
 		if (currentLanguage != null) {
 			List<String> extensions = currentLanguage.getExtensions();
@@ -336,24 +325,22 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 				extension = "." + extensions.get(0);
 			}
 			if (currentLanguage.getLanguageName().equals("Java")) {
-				String name =
-					new TokenFunctions(this).getClassName();
+				String name = new TokenFunctions(this).getClassName();
 				if (name != null) {
 					return name + extension;
 				}
 			}
 		}
-		return (fallBackBaseName == null ? "New_" : fallBackBaseName)
-			+ extension;
+		return (fallBackBaseName == null ? "New_" : fallBackBaseName) + extension;
 	}
 
 	private synchronized void setTitle() {
-		if (frame != null)
-			frame.setTitle();
+		if (frame != null) frame.setTitle();
 	}
 
 	protected void setLanguageByFileName(String name) {
-		setLanguage(frame.scriptService.getLanguageByExtension(FileUtils.getExtension(name)));
+		setLanguage(frame.scriptService.getLanguageByExtension(FileUtils
+			.getExtension(name)));
 	}
 
 	protected void setLanguage(ScriptLanguage language) {
@@ -366,14 +353,15 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		if (language == null) {
 			languageName = "None";
 			defaultExtension = ".txt";
-		} else {
+		}
+		else {
 			languageName = language.getLanguageName();
 			List<String> extensions = language.getExtensions();
-			defaultExtension = extensions.size() == 0 ? "" : ("." + extensions.get(0));
+			defaultExtension =
+				extensions.size() == 0 ? "" : ("." + extensions.get(0));
 		}
-		if (fallBackBaseName != null && fallBackBaseName.endsWith(".txt"))
-			fallBackBaseName = fallBackBaseName.substring(0,
-				fallBackBaseName.length() - 4);
+		if (fallBackBaseName != null && fallBackBaseName.endsWith(".txt")) fallBackBaseName =
+			fallBackBaseName.substring(0, fallBackBaseName.length() - 4);
 		if (file != null) {
 			String name = file.getName();
 			String ext = "." + FileUtils.getExtension(name);
@@ -391,7 +379,8 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		}
 		currentLanguage = language;
 
-		final String styleName = "text/" + languageName.toLowerCase().replace(' ', '-');
+		final String styleName =
+			"text/" + languageName.toLowerCase().replace(' ', '-');
 		setSyntaxEditingStyle(styleName);
 
 		frame.setTitle();
@@ -412,13 +401,11 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	}
 
 	public void increaseFontSize(float factor) {
-		if (factor == 1)
-			return;
+		if (factor == 1) return;
 		SyntaxScheme scheme = getSyntaxScheme();
 		for (int i = 0; i < scheme.getStyleCount(); i++) {
 			Style style = scheme.getStyle(i);
-			if (style == null || style.font == null)
-				continue;
+			if (style == null || style.font == null) continue;
 			float size = Math.max(5, style.font.getSize2D() * factor);
 			style.font = style.font.deriveFont(size);
 		}
@@ -437,7 +424,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	}
 
 	protected RSyntaxDocument getRSyntaxDocument() {
-		return (RSyntaxDocument)getDocument();
+		return (RSyntaxDocument) getDocument();
 	}
 
 	public void toggleBookmark() {
@@ -447,10 +434,12 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	public void toggleBookmark(int line) {
 		if (gutter != null) try {
 			gutter.toggleBookmark(line);
-		} catch (BadLocationException e) { /* ignore */ }
+		}
+		catch (BadLocationException e) { /* ignore */}
 	}
 
 	public class Bookmark {
+
 		int tab;
 		GutterIconInfo info;
 
@@ -462,7 +451,8 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		public int getLineNumber() {
 			try {
 				return getLineOfOffset(info.getMarkedOffset());
-			} catch (BadLocationException e) {
+			}
+			catch (BadLocationException e) {
 				return -1;
 			}
 		}
@@ -521,13 +511,15 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 				inQuotes = false;
 			}
 		}
-		if (count>0) {
+		if (count > 0) {
 			beginAtomicEdit();
 			try {
 				setText(new String(chars));
-			} catch (Throwable t) {
+			}
+			catch (Throwable t) {
 				t.printStackTrace();
-			} finally {
+			}
+			finally {
 				endAtomicEdit();
 			}
 		}
@@ -539,20 +531,25 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		beginAtomicEdit();
 		try {
 			super.convertTabsToSpaces();
-		} catch (Throwable t) {
+		}
+		catch (Throwable t) {
 			t.printStackTrace();
-		} finally {
+		}
+		finally {
 			endAtomicEdit();
 		}
 	}
+
 	@Override
 	public void convertSpacesToTabs() {
 		beginAtomicEdit();
 		try {
 			super.convertSpacesToTabs();
-		} catch (Throwable t) {
+		}
+		catch (Throwable t) {
 			t.printStackTrace();
-		} finally {
+		}
+		finally {
 			endAtomicEdit();
 		}
 	}

--- a/src/main/java/net/imagej/ui/swing/script/EditorPane.java
+++ b/src/main/java/net/imagej/ui/swing/script/EditorPane.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.util.Collection;
+import java.util.EventListener;
 import java.util.List;
 
 import javax.swing.JScrollPane;
@@ -243,7 +244,6 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	 */
 	protected void modified() {
 		checkForOutsideChanges();
-		final boolean update = modifyCount == 0;
 
 		if (undoInProgress) {
 			modifyCount--;
@@ -254,12 +254,6 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		else {
 			// not possible to get back to clean state
 			modifyCount = Integer.MIN_VALUE;
-		}
-
-		if (update || modifyCount == 0) {
-			synchronized (this) {
-				frame.setTitle();
-			}
 		}
 	}
 
@@ -390,10 +384,6 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		updateGitDirectory();
 		
 		if (file != null) {
-			synchronized (this) {
-				frame.setTitle();
-			}
-			
 			setLanguageByFileName(file.getName());
 			fallBackBaseName = null;
 		}
@@ -509,11 +499,6 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		final String styleName =
 			"text/" + languageName.toLowerCase().replace(' ', '-');
 		setSyntaxEditingStyle(styleName);
-
-		synchronized (this) {
-			frame.setTitle();
-		}
-		frame.updateLanguageMenu(language);
 
 		// Add header text
 		if (header != null) {

--- a/src/main/java/net/imagej/ui/swing/script/EditorPane.java
+++ b/src/main/java/net/imagej/ui/swing/script/EditorPane.java
@@ -578,39 +578,14 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	 * @param line line to toggle the bookmark on.
 	 */
 	public void toggleBookmark(final int line) {
-		if (gutter != null) try {
-			gutter.toggleBookmark(line);
-		}
-		catch (final BadLocationException e) { /* ignore */}
-	}
-
-	public class Bookmark {
-
-		int tab;
-		GutterIconInfo info;
-
-		public Bookmark(final int tab, final GutterIconInfo info) {
-			this.tab = tab;
-			this.info = info;
-		}
-
-		public int getLineNumber() {
+		if (gutter != null) {
 			try {
-				return getLineOfOffset(info.getMarkedOffset());
+				gutter.toggleBookmark(line);
 			}
 			catch (final BadLocationException e) {
-				return -1;
+				/* ignore */
+				System.out.println("Cannot toggle bookmark at this location.");
 			}
-		}
-
-		public void setCaret() {
-			frame.switchTo(tab);
-			setCaretPosition(info.getMarkedOffset());
-		}
-
-		@Override
-		public String toString() {
-			return "Line " + (getLineNumber() + 1) + " (" + getFileName() + ")";
 		}
 	}
 
@@ -620,7 +595,9 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	 * @param tab Tab index to set for added bookmarks.
 	 * @param result Collection to add the bookmarks to.
 	 */
-	public void getBookmarks(final int tab, final Collection<Bookmark> result) {
+	public void getBookmarks(final TextEditorTab tab,
+		final Collection<Bookmark> result)
+	{
 		if (gutter == null) return;
 
 		for (final GutterIconInfo info : gutter.getBookmarks())

--- a/src/main/java/net/imagej/ui/swing/script/EditorPane.java
+++ b/src/main/java/net/imagej/ui/swing/script/EditorPane.java
@@ -388,17 +388,13 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	public void setFileName(final File file) {
 		curFile = file;
 		updateGitDirectory();
-		synchronized (this) {
-			frame.setTitle();
-		}
+		
 		if (file != null) {
-			SwingUtilities.invokeLater(new Thread() {
-
-				@Override
-				public void run() {
-					setLanguageByFileName(file.getName());
-				}
-			});
+			synchronized (this) {
+				frame.setTitle();
+			}
+			
+			setLanguageByFileName(file.getName());
 			fallBackBaseName = null;
 		}
 		fileLastModified = file == null || !file.exists() ? 0 : file.lastModified();

--- a/src/main/java/net/imagej/ui/swing/script/EditorPane.java
+++ b/src/main/java/net/imagej/ui/swing/script/EditorPane.java
@@ -243,8 +243,6 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	 * Set the title according to whether the file was modified or not.
 	 */
 	protected void modified() {
-		checkForOutsideChanges();
-
 		if (undoInProgress) {
 			modifyCount--;
 		}
@@ -264,17 +262,6 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	public boolean isNew() {
 		return !fileChanged() && curFile == null && fallBackBaseName == null &&
 			getDocument().getLength() == 0;
-	}
-
-	/**
-	 * Check whether the file was edited outside of this {@link EditorPane} and
-	 * ask the user whether to reload.
-	 */
-	public void checkForOutsideChanges() {
-		if (wasChangedOutside() &&
-			!frame.reload("The file " + curFile.getName() +
-				" was changed outside of the editor")) fileLastModified =
-			curFile.lastModified();
 	}
 
 	/**

--- a/src/main/java/net/imagej/ui/swing/script/EditorPane.java
+++ b/src/main/java/net/imagej/ui/swing/script/EditorPane.java
@@ -81,7 +81,8 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 
 	TextEditor frame;
 	String fallBackBaseName;
-	File file, gitDirectory;
+	File curFile;
+	File gitDirectory;
 	long fileLastModified;
 	ScriptLanguage currentLanguage;
 	Gutter gutter;
@@ -221,19 +222,19 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	}
 
 	public boolean isNew() {
-		return !fileChanged() && file == null && fallBackBaseName == null &&
+		return !fileChanged() && curFile == null && fallBackBaseName == null &&
 			getDocument().getLength() == 0;
 	}
 
 	public void checkForOutsideChanges() {
 		if (wasChangedOutside() &&
-			!frame.reload("The file " + file.getName() +
+			!frame.reload("The file " + curFile.getName() +
 				" was changed outside of the editor")) fileLastModified =
-			file.lastModified();
+			curFile.lastModified();
 	}
 
 	public boolean wasChangedOutside() {
-		return file != null && file.exists() && file.lastModified() != fileLastModified;
+		return curFile != null && curFile.exists() && curFile.lastModified() != fileLastModified;
 	}
 
 	public void write(File file) throws IOException {
@@ -247,8 +248,8 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	}
 
 	public void open(final File file) throws IOException {
-		final File oldFile = this.file;
-		this.file = null;
+		final File oldFile = curFile;
+		curFile = null;
 		if (file == null) setText("");
 		else {
 			int line = 0;
@@ -274,7 +275,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 			}
 			reader.close();
 			setText(string.toString());
-			this.file = file;
+			curFile = file;
 			if (line > getLineCount()) line = getLineCount() - 1;
 			try {
 				setCaretPosition(getLineStartOffset(line));
@@ -305,7 +306,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	}
 
 	public void setFileName(final File file) {
-		this.file = file;
+		curFile = file;
 		updateGitDirectory();
 		synchronized (this) {
 			frame.setTitle();
@@ -324,7 +325,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	}
 
 	protected void updateGitDirectory() {
-		gitDirectory = new FileFunctions(frame).getGitDirectory(file);
+		gitDirectory = new FileFunctions(frame).getGitDirectory(curFile);
 	}
 
 	public File getGitDirectory() {
@@ -332,7 +333,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	}
 
 	protected String getFileName() {
-		if (file != null) return file.getName();
+		if (curFile != null) return curFile.getName();
 		String extension = "";
 		if (currentLanguage != null) {
 			List<String> extensions = currentLanguage.getExtensions();
@@ -373,12 +374,12 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		}
 		if (fallBackBaseName != null && fallBackBaseName.endsWith(".txt")) fallBackBaseName =
 			fallBackBaseName.substring(0, fallBackBaseName.length() - 4);
-		if (file != null) {
-			String name = file.getName();
+		if (curFile != null) {
+			String name = curFile.getName();
 			String ext = "." + FileUtils.getExtension(name);
 			if (!defaultExtension.equals(ext)) {
 				name = name.substring(0, name.length() - ext.length());
-				file = new File(file.getParentFile(), name + defaultExtension);
+				curFile = new File(curFile.getParentFile(), name + defaultExtension);
 				updateGitDirectory();
 				modifyCount = Integer.MIN_VALUE;
 			}

--- a/src/main/java/net/imagej/ui/swing/script/EditorPane.java
+++ b/src/main/java/net/imagej/ui/swing/script/EditorPane.java
@@ -372,7 +372,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	public void setFileName(final File file) {
 		curFile = file;
 		updateGitDirectory();
-		
+
 		if (file != null) {
 			setLanguageByFileName(file.getName());
 			fallBackBaseName = null;

--- a/src/main/java/net/imagej/ui/swing/script/EditorPane.java
+++ b/src/main/java/net/imagej/ui/swing/script/EditorPane.java
@@ -71,6 +71,7 @@ import org.scijava.plugin.Parameter;
 import org.scijava.prefs.PrefService;
 import org.scijava.script.ScriptHeaderService;
 import org.scijava.script.ScriptLanguage;
+import org.scijava.script.ScriptService;
 import org.scijava.util.FileUtils;
 
 /**
@@ -96,6 +97,8 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	private boolean undoInProgress;
 	private boolean redoInProgress;
 
+	@Parameter
+	private ScriptService scriptService;
 	@Parameter
 	private ScriptHeaderService scriptHeaderService;
 	@Parameter
@@ -425,7 +428,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	 * @see #setLanguage(ScriptLanguage, boolean)
 	 */
 	protected void setLanguageByFileName(final String name) {
-		setLanguage(frame.scriptService.getLanguageByExtension(FileUtils
+		setLanguage(scriptService.getLanguageByExtension(FileUtils
 			.getExtension(name)));
 	}
 

--- a/src/main/java/net/imagej/ui/swing/script/FileFunctions.java
+++ b/src/main/java/net/imagej/ui/swing/script/FileFunctions.java
@@ -446,7 +446,7 @@ public class FileFunctions {
 	public class ScreenOutputStream extends LineOutputStream {
 		@Override
 		public void println(String line) {
-			TextEditor.Tab tab = parent.getTab();
+			TextEditorTab tab = parent.getTab();
 			tab.screen.insert(line + "\n", tab.screen.getDocument().getLength());
 		}
 	}

--- a/src/main/java/net/imagej/ui/swing/script/SyntaxHighlighter.java
+++ b/src/main/java/net/imagej/ui/swing/script/SyntaxHighlighter.java
@@ -28,6 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
+
 package net.imagej.ui.swing.script;
 
 import org.fife.ui.rsyntaxtextarea.TokenMaker;
@@ -43,4 +44,6 @@ import org.scijava.plugin.SciJavaPlugin;
  * 
  * @author Johannes Schindelin
  */
-public interface SyntaxHighlighter extends SciJavaPlugin, TokenMaker { }
+public interface SyntaxHighlighter extends SciJavaPlugin, TokenMaker {
+	// NB: Marker interface.
+}

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -1060,7 +1060,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		else if (source == open) {
 			final EditorPane editorPane = getEditorPane();
 			final File defaultDir =
-				editorPane.file != null ? editorPane.file
+				editorPane.curFile != null ? editorPane.curFile
 					.getParentFile() : AppUtils.getBaseDirectory("imagej.dir",
 					TextEditor.class, null);
 			final File file = openWithDialog(defaultDir);
@@ -1190,7 +1190,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		*/
 		else if (source == gitGrep) {
 			String searchTerm = getTextArea().getSelectedText();
-			File searchRoot = getEditorPane().file;
+			File searchRoot = getEditorPane().curFile;
 			if (searchRoot == null) {
 				error("File was not yet saved; no location known!");
 				return;
@@ -1202,7 +1202,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 		else if (source == openInGitweb) {
 			EditorPane editorPane = getEditorPane();
-			new FileFunctions(this).openInGitweb(editorPane.file,
+			new FileFunctions(this).openInGitweb(editorPane.curFile,
 				editorPane.gitDirectory, editorPane.getCaretLineNumber() + 1);
 		}
 		else if (source == increaseFontSize || source == decreaseFontSize) {
@@ -1301,7 +1301,7 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public boolean reload(String message) {
-		File file = getEditorPane().file;
+		File file = getEditorPane().curFile;
 		if (file == null || !file.exists()) return true;
 
 		boolean modified = getEditorPane().fileChanged();
@@ -1501,7 +1501,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			final JTextAreaWriter output =
 				new JTextAreaWriter(this.screen, TextEditor.this.log);
 			final JTextAreaWriter errors = new JTextAreaWriter(errorScreen, log);
-			final File file = getEditorPane().file;
+			final File file = getEditorPane().curFile;
 			// Pipe current text into the runScript:
 			final PipedInputStream pi = new PipedInputStream();
 			final PipedOutputStream po = new PipedOutputStream(pi);
@@ -1676,7 +1676,7 @@ public class TextEditor extends JFrame implements ActionListener,
 					tabsMenuItems.add(addToMenu(tabsMenu, tab.editorPane.getFileName(),
 						0, 0));
 				}
-				setFileName(tab.editorPane.file);
+				setFileName(tab.editorPane.curFile);
 				try {
 					updateTabAndFontSize(true);
 				}
@@ -1701,7 +1701,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	public boolean saveAs() {
 		EditorPane editorPane = getEditorPane();
-		File file = editorPane.file;
+		File file = editorPane.curFile;
 		if (file == null) {
 			final File ijDir =
 				AppUtils.getBaseDirectory("imagej.dir", TextEditor.class, null);
@@ -1729,7 +1729,7 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public boolean save() {
-		File file = getEditorPane().file;
+		File file = getEditorPane().curFile;
 		if (file == null) return saveAs();
 		if (!write(file)) return false;
 		setTitle();
@@ -1749,7 +1749,7 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public boolean makeJar(boolean includeSources) {
-		File file = getEditorPane().file;
+		File file = getEditorPane().curFile;
 		if ((file == null || isCompiled()) && !handleUnsavedChanges(true)) {
 			return false;
 		}
@@ -1792,7 +1792,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 				@Override
 				public void run() {
-					java.makeJar(getEditorPane().file, includeSources, file, errors);
+					java.makeJar(getEditorPane().curFile, includeSources, file, errors);
 					errorScreen.insert("Compilation finished.\n", errorScreen
 						.getDocument().getLength());
 					markCompileEnd();
@@ -2191,7 +2191,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		final JTextAreaWriter output = new JTextAreaWriter(getTab().screen, log);
 		final JTextAreaWriter errors = new JTextAreaWriter(errorScreen, log);
 
-		final File file = getEditorPane().file;
+		final File file = getEditorPane().curFile;
 		new TextEditor.Executer(output, errors) {
 
 			@Override
@@ -2199,7 +2199,7 @@ public class TextEditor extends JFrame implements ActionListener,
 				Reader reader = null;
 				try {
 					reader =
-						evalScript(getEditorPane().file.getPath(), new FileReader(file),
+						evalScript(getEditorPane().curFile.getPath(), new FileReader(file),
 							output, errors);
 
 					output.flush();
@@ -2236,7 +2236,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 				@Override
 				public void run() {
-					java.compile(getEditorPane().file, errors);
+					java.compile(getEditorPane().curFile, errors);
 					errorScreen.insert("Compilation finished.\n", errorScreen
 						.getDocument().getLength());
 					markCompileEnd();
@@ -2367,8 +2367,8 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	boolean editorPaneContainsFile(EditorPane editorPane, File file) {
 		try {
-			return file != null && editorPane != null && editorPane.file != null &&
-				file.getCanonicalFile().equals(editorPane.file.getCanonicalFile());
+			return file != null && editorPane != null && editorPane.curFile != null &&
+				file.getCanonicalFile().equals(editorPane.curFile.getCanonicalFile());
 		}
 		catch (IOException e) {
 			return false;
@@ -2376,14 +2376,14 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public File getFile() {
-		return getEditorPane().file;
+		return getEditorPane().curFile;
 	}
 
 	public File getFileForBasename(String baseName) {
 		File file = getFile();
 		if (file != null && file.getName().equals(baseName)) return file;
 		for (int i = 0; i < tabbed.getTabCount(); i++) {
-			file = getEditorPane(i).file;
+			file = getEditorPane(i).curFile;
 			if (file != null && file.getName().equals(baseName)) return file;
 		}
 		return null;

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -1407,7 +1407,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			scroll.setPreferredSize(new Dimension(600, 80));
 			bottom.add(scroll, bc);
 
-			super.setTopComponent(editorPane.embedWithScrollbars());
+			super.setTopComponent(editorPane.wrappedInScrollbars());
 			super.setBottomComponent(bottom);
 		}
 

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -1265,10 +1265,13 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public void listBookmarks() {
-		final Vector<EditorPane.Bookmark> bookmarks =
-			new Vector<EditorPane.Bookmark>();
-		for (int i = 0; i < tabbed.getTabCount(); i++)
-			getEditorPane(i).getBookmarks(i, bookmarks);
+		final Vector<Bookmark> bookmarks = new Vector<Bookmark>();
+
+		for (int i = 0; i < tabbed.getTabCount(); i++) {
+			TextEditorTab tab = (TextEditorTab) tabbed.getComponentAt(i);
+			tab.editorPane.getBookmarks(tab, bookmarks);
+		}
+		
 		final BookmarkDialog dialog = new BookmarkDialog(this, bookmarks);
 		dialog.setVisible(true);
 	}

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -8,13 +8,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -150,7 +150,7 @@ import org.scijava.widget.FileWidget;
  * SciJava scripting</a>, it is even possible to develop Java plugins in the
  * editor.
  * </p>
- * 
+ *
  * @author Johannes Schindelin
  * @author Jonathan Hale
  */
@@ -238,12 +238,12 @@ public class TextEditor extends JFrame implements ActionListener,
 		loadPreferences();
 
 		// Initialize menu
-		int ctrl = Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
-		int shift = ActionEvent.SHIFT_MASK;
-		JMenuBar mbar = new JMenuBar();
+		final int ctrl = Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
+		final int shift = ActionEvent.SHIFT_MASK;
+		final JMenuBar mbar = new JMenuBar();
 		setJMenuBar(mbar);
 
-		JMenu file = new JMenu("File");
+		final JMenu file = new JMenu("File");
 		file.setMnemonic(KeyEvent.VK_F);
 		newFile = addToMenu(file, "New", KeyEvent.VK_N, ctrl);
 		newFile.setMnemonic(KeyEvent.VK_N);
@@ -266,7 +266,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		mbar.add(file);
 
-		JMenu edit = new JMenu("Edit");
+		final JMenu edit = new JMenu("Edit");
 		edit.setMnemonic(KeyEvent.VK_E);
 		undo = addToMenu(edit, "Undo", KeyEvent.VK_Z, ctrl);
 		redo = addToMenu(edit, "Redo", KeyEvent.VK_Y, ctrl);
@@ -301,20 +301,21 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		fontSizeMenu = new JMenu("Font sizes");
 		fontSizeMenu.setMnemonic(KeyEvent.VK_Z);
-		boolean[] fontSizeShortcutUsed = new boolean[10];
-		ButtonGroup buttonGroup = new ButtonGroup();
+		final boolean[] fontSizeShortcutUsed = new boolean[10];
+		final ButtonGroup buttonGroup = new ButtonGroup();
 		for (final int size : new int[] { 8, 10, 12, 16, 20, 28, 42 }) {
-			JRadioButtonMenuItem item = new JRadioButtonMenuItem("" + size + " pt");
+			final JRadioButtonMenuItem item =
+				new JRadioButtonMenuItem("" + size + " pt");
 			item.addActionListener(new ActionListener() {
 
 				@Override
-				public void actionPerformed(ActionEvent event) {
+				public void actionPerformed(final ActionEvent event) {
 					getEditorPane().setFontSize(size);
 					updateTabAndFontSize(false);
 				}
 			});
-			for (char c : ("" + size).toCharArray()) {
-				int digit = c - '0';
+			for (final char c : ("" + size).toCharArray()) {
+				final int digit = c - '0';
 				if (!fontSizeShortcutUsed[digit]) {
 					item.setMnemonic(KeyEvent.VK_0 + digit);
 					fontSizeShortcutUsed[digit] = true;
@@ -334,13 +335,13 @@ public class TextEditor extends JFrame implements ActionListener,
 		// Add tab size adjusting menu
 		tabSizeMenu = new JMenu("Tab sizes");
 		tabSizeMenu.setMnemonic(KeyEvent.VK_T);
-		ButtonGroup bg = new ButtonGroup();
+		final ButtonGroup bg = new ButtonGroup();
 		for (final int size : new int[] { 2, 4, 8 }) {
-			JRadioButtonMenuItem item = new JRadioButtonMenuItem("" + size);
+			final JRadioButtonMenuItem item = new JRadioButtonMenuItem("" + size);
 			item.addActionListener(new ActionListener() {
 
 				@Override
-				public void actionPerformed(ActionEvent event) {
+				public void actionPerformed(final ActionEvent event) {
 					getEditorPane().setTabSize(size);
 					updateTabAndFontSize(false);
 				}
@@ -360,7 +361,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		wrapLines.addChangeListener(new ChangeListener() {
 
 			@Override
-			public void stateChanged(ChangeEvent e) {
+			public void stateChanged(final ChangeEvent e) {
 				getEditorPane().setLineWrap(wrapLines.getState());
 			}
 		});
@@ -371,7 +372,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		tabsEmulated.addChangeListener(new ChangeListener() {
 
 			@Override
-			public void stateChanged(ChangeEvent e) {
+			public void stateChanged(final ChangeEvent e) {
 				getEditorPane().setTabsEmulated(tabsEmulated.getState());
 			}
 		});
@@ -399,7 +400,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		autoImport.addItemListener(new ItemListener() {
 
 			@Override
-			public void itemStateChanged(ItemEvent e) {
+			public void itemStateChanged(final ItemEvent e) {
 				respectAutoImports = e.getStateChange() == ItemEvent.SELECTED;
 				prefService.put(AUTO_IMPORT_PREFS, respectAutoImports);
 			}
@@ -423,7 +424,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		toggleWhiteSpaceLabeling.addActionListener(new ActionListener() {
 
 			@Override
-			public void actionPerformed(ActionEvent e) {
+			public void actionPerformed(final ActionEvent e) {
 				getTextArea().setWhitespaceVisible(
 					toggleWhiteSpaceLabeling.isSelected());
 			}
@@ -434,10 +435,10 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		languageMenuItems =
 			new LinkedHashMap<ScriptLanguage, JRadioButtonMenuItem>();
-		Set<Integer> usedShortcuts = new HashSet<Integer>();
-		JMenu languages = new JMenu("Language");
+		final Set<Integer> usedShortcuts = new HashSet<Integer>();
+		final JMenu languages = new JMenu("Language");
 		languages.setMnemonic(KeyEvent.VK_L);
-		ButtonGroup group = new ButtonGroup();
+		final ButtonGroup group = new ButtonGroup();
 
 		// get list of languages, and sort them by name
 		final ArrayList<ScriptLanguage> list =
@@ -453,13 +454,14 @@ public class TextEditor extends JFrame implements ActionListener,
 		});
 		list.add(null);
 
-		Map<String, ScriptLanguage> languageMap =
+		final Map<String, ScriptLanguage> languageMap =
 			new HashMap<String, ScriptLanguage>();
 		for (final ScriptLanguage language : list) {
-			String name = language == null ? "None" : language.getLanguageName();
+			final String name =
+				language == null ? "None" : language.getLanguageName();
 			languageMap.put(name, language);
 
-			JRadioButtonMenuItem item = new JRadioButtonMenuItem(name);
+			final JRadioButtonMenuItem item = new JRadioButtonMenuItem(name);
 			if (language == null) {
 				noneLanguageItem = item;
 			}
@@ -468,8 +470,8 @@ public class TextEditor extends JFrame implements ActionListener,
 			}
 
 			int shortcut = -1;
-			for (char ch : name.toCharArray()) {
-				int keyCode = KeyStroke.getKeyStroke(ch, 0).getKeyCode();
+			for (final char ch : name.toCharArray()) {
+				final int keyCode = KeyStroke.getKeyStroke(ch, 0).getKeyCode();
 				if (usedShortcuts.contains(keyCode)) continue;
 				shortcut = keyCode;
 				usedShortcuts.add(shortcut);
@@ -479,7 +481,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			item.addActionListener(new ActionListener() {
 
 				@Override
-				public void actionPerformed(ActionEvent e) {
+				public void actionPerformed(final ActionEvent e) {
 					setLanguage(language, true);
 				}
 			});
@@ -490,7 +492,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		noneLanguageItem.setSelected(true);
 		mbar.add(languages);
 
-		JMenu templates = new JMenu("Templates");
+		final JMenu templates = new JMenu("Templates");
 		templates.setMnemonic(KeyEvent.VK_T);
 		addTemplates(templates, languageMap);
 		mbar.add(templates);
@@ -595,7 +597,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		addWindowListener(new WindowAdapter() {
 
 			@Override
-			public void windowClosing(WindowEvent e) {
+			public void windowClosing(final WindowEvent e) {
 				if (!confirmClose()) return;
 				dispose();
 			}
@@ -604,13 +606,13 @@ public class TextEditor extends JFrame implements ActionListener,
 		addWindowFocusListener(new WindowAdapter() {
 
 			@Override
-			public void windowGainedFocus(WindowEvent e) {
+			public void windowGainedFocus(final WindowEvent e) {
 				final EditorPane editorPane = getEditorPane();
 				editorPane.checkForOutsideChanges();
 			}
 		});
 
-		Font font = new Font("Courier", Font.PLAIN, 12);
+		final Font font = new Font("Courier", Font.PLAIN, 12);
 		errorScreen.setFont(font);
 		errorScreen.setEditable(false);
 		errorScreen.setLineWrap(true);
@@ -631,14 +633,16 @@ public class TextEditor extends JFrame implements ActionListener,
 				});
 			}
 		}
-		catch (Exception ie) {}
+		catch (final Exception ie) {
+			/* ignore */
+		}
 		findDialog = new FindAndReplaceDialog(this);
 
 		// Save the size of the window in the preferences
 		addComponentListener(new ComponentAdapter() {
 
 			@Override
-			public void componentResized(ComponentEvent e) {
+			public void componentResized(final ComponentEvent e) {
 				saveWindowSizeToPrefs();
 			}
 		});
@@ -663,7 +667,7 @@ public class TextEditor extends JFrame implements ActionListener,
 				tokenMakerFactory.putMapping("text/" + info.getLabel(), info
 					.getClassName());
 			}
-			catch (Throwable t) {
+			catch (final Throwable t) {
 				log.warn("Could not register " + info.getLabel(), t);
 			}
 	}
@@ -681,23 +685,32 @@ public class TextEditor extends JFrame implements ActionListener,
 	@Plugin(type = SyntaxHighlighter.class, label = "ecmascript")
 	public static class ECMAScriptHighlighter extends JavaScriptTokenMaker
 		implements SyntaxHighlighter
-	{}
+	{
+		// Everything implemented in JavaScriptTokenMaker
+	}
 
 	@Plugin(type = SyntaxHighlighter.class, label = "matlab")
 	public static class MatlabHighlighter extends MatlabTokenMaker implements
 		SyntaxHighlighter
-	{}
+	{
+		// Everything implemented in MatlabTokenMaker
+	}
 
 	@Plugin(type = SyntaxHighlighter.class, label = "ij1-macro")
 	public static class IJ1MacroHighlighter extends ImageJMacroTokenMaker
 		implements SyntaxHighlighter
-	{}
+	{
+		// Everything implemented in ImageJMacroTokenMaker
+	}
 
 	@Plugin(type = SyntaxHighlighter.class, label = "beanshell")
 	public static class BeanshellHighlighter extends JavaTokenMaker implements
 		SyntaxHighlighter
-	{}
+	{
+		// Everything implemented in JavaTokenMaker
+	}
 
+	@SuppressWarnings("unused")
 	@EventHandler
 	private void onEvent(final ContextDisposingEvent e) {
 		if (isDisplayable()) dispose();
@@ -707,7 +720,7 @@ public class TextEditor extends JFrame implements ActionListener,
 	 * Loads the preferences for the JFrame from file
 	 */
 	public void loadPreferences() {
-		Dimension dim = getSize();
+		final Dimension dim = getSize();
 
 		// If a dimension is 0 then use the default dimension size
 		if (0 == dim.width) {
@@ -730,7 +743,7 @@ public class TextEditor extends JFrame implements ActionListener,
 	 * </p>
 	 */
 	public void saveWindowSizeToPrefs() {
-		Dimension dim = getSize();
+		final Dimension dim = getSize();
 		prefService.put(WINDOW_HEIGHT, dim.height);
 		prefService.put(WINDOW_WIDTH, dim.width);
 	}
@@ -741,11 +754,11 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	/**
 	 * Get the currently selected tab.
-	 * 
+	 *
 	 * @return The currently selected tab. Never null.
 	 */
 	public Tab getTab() {
-		int index = tabbed.getSelectedIndex();
+		final int index = tabbed.getSelectedIndex();
 		if (index < 0) {
 			// should not happen, but safety first.
 			if (tabbed.getTabCount() == 0) {
@@ -760,17 +773,17 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	/**
 	 * Get tab at provided index.
-	 * 
+	 *
 	 * @param index the index of the tab.
 	 * @return the {@link Tab} at given index or <code>null</code>.
 	 */
-	public Tab getTab(int index) {
+	public Tab getTab(final int index) {
 		return (Tab) tabbed.getComponentAt(index);
 	}
 
 	/**
 	 * Return the {@link EditorPane} of the currently selected {@link Tab}.
-	 * 
+	 *
 	 * @return the current {@link EditorPane}. Never <code>null</code>.
 	 */
 	public EditorPane getEditorPane() {
@@ -781,10 +794,10 @@ public class TextEditor extends JFrame implements ActionListener,
 		return getEditorPane().getCurrentLanguage();
 	}
 
-	public JMenuItem addToMenu(JMenu menu, String menuEntry, int key,
-		int modifiers)
+	public JMenuItem addToMenu(final JMenu menu, final String menuEntry,
+		final int key, final int modifiers)
 	{
-		JMenuItem item = new JMenuItem(menuEntry);
+		final JMenuItem item = new JMenuItem(menuEntry);
 		menu.add(item);
 		if (key != 0) item.setAccelerator(KeyStroke.getKeyStroke(key, modifiers));
 		item.addActionListener(this);
@@ -800,63 +813,64 @@ public class TextEditor extends JFrame implements ActionListener,
 	protected List<AcceleratorTriplet> defaultAccelerators =
 		new ArrayList<AcceleratorTriplet>();
 
-	public void addAccelerator(final JMenuItem component, int key, int modifiers)
+	public void addAccelerator(final JMenuItem component, final int key,
+		final int modifiers)
 	{
 		addAccelerator(component, key, modifiers, false);
 	}
 
-	public void addAccelerator(final JMenuItem component, int key, int modifiers,
-		boolean record)
+	public void addAccelerator(final JMenuItem component, final int key,
+		final int modifiers, final boolean record)
 	{
 		if (record) {
-			AcceleratorTriplet triplet = new AcceleratorTriplet();
+			final AcceleratorTriplet triplet = new AcceleratorTriplet();
 			triplet.component = component;
 			triplet.key = key;
 			triplet.modifiers = modifiers;
 			defaultAccelerators.add(triplet);
 		}
 
-		RSyntaxTextArea textArea = getTextArea();
+		final RSyntaxTextArea textArea = getTextArea();
 		if (textArea != null) addAccelerator(textArea, component, key, modifiers);
 	}
 
-	public void addAccelerator(RSyntaxTextArea textArea,
-		final JMenuItem component, int key, int modifiers)
+	public void addAccelerator(final RSyntaxTextArea textArea,
+		final JMenuItem component, final int key, final int modifiers)
 	{
 		textArea.getInputMap().put(KeyStroke.getKeyStroke(key, modifiers),
 			component);
 		textArea.getActionMap().put(component, new AbstractAction() {
 
 			@Override
-			public void actionPerformed(ActionEvent e) {
+			public void actionPerformed(final ActionEvent e) {
 				if (!component.isEnabled()) return;
-				ActionEvent event = new ActionEvent(component, 0, "Accelerator");
+				final ActionEvent event = new ActionEvent(component, 0, "Accelerator");
 				TextEditor.this.actionPerformed(event);
 			}
 		});
 	}
 
-	public void addDefaultAccelerators(RSyntaxTextArea textArea) {
-		for (AcceleratorTriplet triplet : defaultAccelerators)
+	public void addDefaultAccelerators(final RSyntaxTextArea textArea) {
+		for (final AcceleratorTriplet triplet : defaultAccelerators)
 			addAccelerator(textArea, triplet.component, triplet.key,
 				triplet.modifiers);
 	}
 
-	protected JMenu getMenu(JMenu root, String menuItemPath,
-		boolean createIfNecessary)
+	protected JMenu getMenu(final JMenu root, final String menuItemPath,
+		final boolean createIfNecessary)
 	{
-		int gt = menuItemPath.indexOf('>');
+		final int gt = menuItemPath.indexOf('>');
 		if (gt < 0) return root;
 
-		String menuLabel = menuItemPath.substring(0, gt);
-		String rest = menuItemPath.substring(gt + 1);
+		final String menuLabel = menuItemPath.substring(0, gt);
+		final String rest = menuItemPath.substring(gt + 1);
 		for (int i = 0; i < root.getItemCount(); i++) {
-			JMenuItem item = root.getItem(i);
+			final JMenuItem item = root.getItem(i);
 			if ((item instanceof JMenu) && menuLabel.equals(item.getText())) return getMenu(
 				(JMenu) item, rest, createIfNecessary);
 		}
 		if (!createIfNecessary) return null;
-		JMenu subMenu = new JMenu(menuLabel);
+		final JMenu subMenu = new JMenu(menuLabel);
 		root.add(subMenu);
 		return getMenu(subMenu, rest, createIfNecessary);
 	}
@@ -872,19 +886,19 @@ public class TextEditor extends JFrame implements ActionListener,
 	 * The sub menus of the template menu correspond to language names; Entries
 	 * for languages unknown to the script service will be discarded quietly.
 	 * </p>
-	 * 
+	 *
 	 * @param templatesMenu the top-level menu to populate
 	 * @param languageMap the known languages
 	 */
-	protected void addTemplates(JMenu templatesMenu,
-		Map<String, ScriptLanguage> languageMap)
+	protected void addTemplates(final JMenu templatesMenu,
+		final Map<String, ScriptLanguage> languageMap)
 	{
 		for (final String templatePath : TEMPLATE_PATHS) {
 			for (final Map.Entry<String, URL> entry : new TreeMap<String, URL>(
 				FileFunctions.findResources(null, templatePath)).entrySet())
 			{
 				final String path = entry.getKey().replace('/', '>').replace('_', ' ');
-				int gt = path.indexOf('>');
+				final int gt = path.indexOf('>');
 				if (gt < 1) {
 					log.warn("Ignoring invalid editor template: " + entry.getValue());
 					continue;
@@ -907,7 +921,7 @@ public class TextEditor extends JFrame implements ActionListener,
 				item.addActionListener(new ActionListener() {
 
 					@Override
-					public void actionPerformed(ActionEvent e) {
+					public void actionPerformed(final ActionEvent e) {
 						loadTemplate(url, engine);
 					}
 				});
@@ -924,7 +938,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		try {
 			loadTemplate(new URL(url));
 		}
-		catch (Exception e) {
+		catch (final Exception e) {
 			log.error(e);
 			error("The template '" + url + "' was not found.");
 		}
@@ -932,7 +946,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	public void loadTemplate(final URL url) {
 		final String path = url.getPath();
-		int dot = path.lastIndexOf('.');
+		final int dot = path.lastIndexOf('.');
 		ScriptLanguage language = null;
 		if (dot > 0) {
 			language = scriptService.getLanguageByExtension(path.substring(dot + 1));
@@ -945,7 +959,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		try {
 			// Load the template
-			InputStream in = url.openStream();
+			final InputStream in = url.openStream();
 			getTextArea().read(new BufferedReader(new InputStreamReader(in)), null);
 
 			if (language != null) {
@@ -954,7 +968,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			final String path = url.getPath();
 			setFileName(path.substring(path.lastIndexOf('/') + 1));
 		}
-		catch (Exception e) {
+		catch (final Exception e) {
 			e.printStackTrace();
 			error("The template '" + url + "' was not found.");
 		}
@@ -964,7 +978,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		open(null);
 	}
 
-	public void createNewDocument(String title, String text) {
+	public void createNewDocument(final String title, final String text) {
 		open(null);
 		final EditorPane editorPane = getEditorPane();
 		editorPane.setText(text);
@@ -977,14 +991,14 @@ public class TextEditor extends JFrame implements ActionListener,
 	 * Open a new editor to edit the given file, with a templateFile if the file
 	 * does not exist yet
 	 */
-	public void createNewFromTemplate(File file, File templateFile) {
+	public void createNewFromTemplate(final File file, final File templateFile) {
 		open(file.exists() ? file : templateFile);
 		if (!file.exists()) {
 			final EditorPane editorPane = getEditorPane();
 			try {
 				editorPane.open(file);
 			}
-			catch (IOException e) {
+			catch (final IOException e) {
 				handleException(e);
 			}
 			editorPane.setLanguageByFileName(file.getName());
@@ -1000,7 +1014,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		return handleUnsavedChanges(false);
 	}
 
-	public boolean handleUnsavedChanges(boolean beforeCompiling) {
+	public boolean handleUnsavedChanges(final boolean beforeCompiling) {
 		if (!fileChanged()) return true;
 
 		if (beforeCompiling && autoSave.getState()) {
@@ -1038,15 +1052,14 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	@Override
-	public void actionPerformed(ActionEvent ae) {
+	public void actionPerformed(final ActionEvent ae) {
 		final Object source = ae.getSource();
 		if (source == newFile) createNewDocument();
 		else if (source == open) {
 			final EditorPane editorPane = getEditorPane();
 			final File defaultDir =
-				editorPane.getFile() != null ? editorPane.getFile()
-					.getParentFile() : AppUtils.getBaseDirectory("imagej.dir",
-					TextEditor.class, null);
+				editorPane.getFile() != null ? editorPane.getFile().getParentFile()
+					: AppUtils.getBaseDirectory("imagej.dir", TextEditor.class, null);
 			final File file = openWithDialog(defaultDir);
 			if (file != null) new Thread() {
 
@@ -1133,26 +1146,26 @@ public class TextEditor extends JFrame implements ActionListener,
 		else if (source == openMacroFunctions) try {
 			new MacroFunctions(this).openHelp(getTextArea().getSelectedText());
 		}
-		catch (IOException e) {
+		catch (final IOException e) {
 			handleException(e);
 		}
 		else if (source == extractSourceJar) extractSourceJar();
 		else if (source == openSourceForClass) {
-			String className = getSelectedClassNameOrAsk();
+			final String className = getSelectedClassNameOrAsk();
 			if (className != null) try {
-				String path = new FileFunctions(this).getSourcePath(className);
+				final String path = new FileFunctions(this).getSourcePath(className);
 				if (path != null) open(new File(path));
 				else {
-					String url = new FileFunctions(this).getSourceURL(className);
+					final String url = new FileFunctions(this).getSourceURL(className);
 					try {
 						platformService.open(new URL(url));
 					}
-					catch (Throwable e) {
+					catch (final Throwable e) {
 						handleException(e);
 					}
 				}
 			}
-			catch (ClassNotFoundException e) {
+			catch (final ClassNotFoundException e) {
 				error("Could not open source for class " + className);
 			}
 		}
@@ -1175,7 +1188,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 		*/
 		else if (source == gitGrep) {
-			String searchTerm = getTextArea().getSelectedText();
+			final String searchTerm = getTextArea().getSelectedText();
 			File searchRoot = getEditorPane().getFile();
 			if (searchRoot == null) {
 				error("File was not yet saved; no location known!");
@@ -1187,9 +1200,9 @@ public class TextEditor extends JFrame implements ActionListener,
 				searchTerm, "searchRoot", searchRoot);
 		}
 		else if (source == openInGitweb) {
-			EditorPane editorPane = getEditorPane();
-			new FileFunctions(this).openInGitweb(editorPane.getFile(),
-				editorPane.getGitDirectory(), editorPane.getCaretLineNumber() + 1);
+			final EditorPane editorPane = getEditorPane();
+			new FileFunctions(this).openInGitweb(editorPane.getFile(), editorPane
+				.getGitDirectory(), editorPane.getCaretLineNumber() + 1);
 		}
 		else if (source == increaseFontSize || source == decreaseFontSize) {
 			getEditorPane().increaseFontSize(
@@ -1201,9 +1214,9 @@ public class TextEditor extends JFrame implements ActionListener,
 		else if (handleTabsMenu(source)) return;
 	}
 
-	protected boolean handleTabsMenu(Object source) {
+	protected boolean handleTabsMenu(final Object source) {
 		if (!(source instanceof JMenuItem)) return false;
-		JMenuItem item = (JMenuItem) source;
+		final JMenuItem item = (JMenuItem) source;
 		if (!tabsMenuItems.contains(item)) return false;
 		for (int i = tabsMenuTabsStart; i < tabsMenu.getItemCount(); i++)
 			if (tabsMenu.getItem(i) == item) {
@@ -1214,8 +1227,8 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	@Override
-	public void stateChanged(ChangeEvent e) {
-		int index = tabbed.getSelectedIndex();
+	public void stateChanged(final ChangeEvent e) {
+		final int index = tabbed.getSelectedIndex();
 		if (index < 0) {
 			setTitle("");
 			return;
@@ -1235,38 +1248,38 @@ public class TextEditor extends JFrame implements ActionListener,
 		});
 	}
 
-	public EditorPane getEditorPane(int index) {
+	public EditorPane getEditorPane(final int index) {
 		return getTab(index).editorPane;
 	}
 
-	public void findOrReplace(boolean replace) {
+	public void findOrReplace(final boolean replace) {
 		findDialog.setLocationRelativeTo(this);
 
 		// override search pattern only if
 		// there is sth. selected
-		String selection = getTextArea().getSelectedText();
+		final String selection = getTextArea().getSelectedText();
 		if (selection != null) findDialog.setSearchPattern(selection);
 
 		findDialog.show(replace);
 	}
 
 	public void gotoLine() {
-		String line =
+		final String line =
 			JOptionPane.showInputDialog(this, "Line:", "Goto line...",
 				JOptionPane.QUESTION_MESSAGE);
 		if (line == null) return;
 		try {
 			gotoLine(Integer.parseInt(line));
 		}
-		catch (BadLocationException e) {
+		catch (final BadLocationException e) {
 			error("Line number out of range: " + line);
 		}
-		catch (NumberFormatException e) {
+		catch (final NumberFormatException e) {
 			error("Invalid line number: " + line);
 		}
 	}
 
-	public void gotoLine(int line) throws BadLocationException {
+	public void gotoLine(final int line) throws BadLocationException {
 		getTextArea().setCaretPosition(getTextArea().getLineStartOffset(line - 1));
 	}
 
@@ -1275,10 +1288,11 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public void listBookmarks() {
-		Vector<EditorPane.Bookmark> bookmarks = new Vector<EditorPane.Bookmark>();
+		final Vector<EditorPane.Bookmark> bookmarks =
+			new Vector<EditorPane.Bookmark>();
 		for (int i = 0; i < tabbed.getTabCount(); i++)
 			getEditorPane(i).getBookmarks(i, bookmarks);
-		BookmarkDialog dialog = new BookmarkDialog(this, bookmarks);
+		final BookmarkDialog dialog = new BookmarkDialog(this, bookmarks);
 		dialog.setVisible(true);
 	}
 
@@ -1286,12 +1300,12 @@ public class TextEditor extends JFrame implements ActionListener,
 		return reload("Reload the file?");
 	}
 
-	public boolean reload(String message) {
-		File file = getEditorPane().getFile();
+	public boolean reload(final String message) {
+		final File file = getEditorPane().getFile();
 		if (file == null || !file.exists()) return true;
 
-		boolean modified = getEditorPane().fileChanged();
-		String[] options = { "Reload", "Do not reload" };
+		final boolean modified = getEditorPane().fileChanged();
+		final String[] options = { "Reload", "Do not reload" };
 		if (modified) options[0] = "Reload (discarding changes)";
 		switch (JOptionPane.showOptionDialog(this, message, "Reload",
 			JOptionPane.DEFAULT_OPTION, JOptionPane.WARNING_MESSAGE, null, options,
@@ -1301,7 +1315,7 @@ public class TextEditor extends JFrame implements ActionListener,
 					getEditorPane().open(file);
 					return true;
 				}
-				catch (IOException e) {
+				catch (final IOException e) {
 					error("Could not reload " + file.getPath());
 				}
 				break;
@@ -1326,9 +1340,9 @@ public class TextEditor extends JFrame implements ActionListener,
 			screen.setLineWrap(true);
 			screen.setFont(new Font("Courier", Font.PLAIN, 12));
 
-			JPanel bottom = new JPanel();
+			final JPanel bottom = new JPanel();
 			bottom.setLayout(new GridBagLayout());
-			GridBagConstraints bc = new GridBagConstraints();
+			final GridBagConstraints bc = new GridBagConstraints();
 
 			bc.gridx = 0;
 			bc.gridy = 0;
@@ -1340,7 +1354,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			runit.addActionListener(new ActionListener() {
 
 				@Override
-				public void actionPerformed(ActionEvent ae) {
+				public void actionPerformed(final ActionEvent ae) {
 					runText();
 				}
 			});
@@ -1352,7 +1366,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			killit.addActionListener(new ActionListener() {
 
 				@Override
-				public void actionPerformed(ActionEvent ae) {
+				public void actionPerformed(final ActionEvent ae) {
 					kill();
 				}
 			});
@@ -1371,7 +1385,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			toggleErrors.addActionListener(new ActionListener() {
 
 				@Override
-				public void actionPerformed(ActionEvent e) {
+				public void actionPerformed(final ActionEvent e) {
 					toggleErrors();
 				}
 			});
@@ -1381,11 +1395,11 @@ public class TextEditor extends JFrame implements ActionListener,
 			bc.fill = GridBagConstraints.NONE;
 			bc.weightx = 0;
 			bc.anchor = GridBagConstraints.NORTHEAST;
-			JButton clear = new JButton("Clear");
+			final JButton clear = new JButton("Clear");
 			clear.addActionListener(new ActionListener() {
 
 				@Override
-				public void actionPerformed(ActionEvent ae) {
+				public void actionPerformed(final ActionEvent ae) {
 					if (showingErrors) errorScreen.setText("");
 					else screen.setText("");
 				}
@@ -1401,7 +1415,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			bc.gridwidth = 5;
 			screen.setEditable(false);
 			screen.setLineWrap(true);
-			Font font = new Font("Courier", Font.PLAIN, 12);
+			final Font font = new Font("Courier", Font.PLAIN, 12);
 			screen.setFont(font);
 			scroll = new JScrollPane(screen);
 			scroll.setPreferredSize(new Dimension(600, 80));
@@ -1489,7 +1503,7 @@ public class TextEditor extends JFrame implements ActionListener,
 						errors.flush();
 						markCompileEnd();
 					}
-					catch (Throwable t) {
+					catch (final Throwable t) {
 						output.flush();
 						errors.flush();
 						if (t instanceof ScriptException && t.getCause() != null &&
@@ -1512,7 +1526,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			try {
 				final String text;
 				if (selectionOnly) {
-					String selected = editorPane.getSelectedText();
+					final String selected = editorPane.getSelectedText();
 					if (selected == null) {
 						error("Selection required!");
 						text = null;
@@ -1530,20 +1544,20 @@ public class TextEditor extends JFrame implements ActionListener,
 
 					@Override
 					public void run() {
-						PrintWriter pw = new PrintWriter(po);
+						final PrintWriter pw = new PrintWriter(po);
 						pw.write(text);
 						pw.flush(); // will lock and wait in some cases
 						try {
 							po.close();
 						}
-						catch (Throwable tt) {
+						catch (final Throwable tt) {
 							tt.printStackTrace();
 						}
 						pw.close();
 					}
 				}.start();
 			}
-			catch (Throwable t) {
+			catch (final Throwable t) {
 				t.printStackTrace();
 			}
 			finally {
@@ -1570,7 +1584,9 @@ public class TextEditor extends JFrame implements ActionListener,
 						try {
 							Thread.sleep(100);
 						}
-						catch (InterruptedException e) {}
+						catch (final InterruptedException e) {
+							/* ignore */
+						}
 					if (null != executer) executer.obliterate();
 					restore();
 
@@ -1579,16 +1595,16 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 	}
 
-	public static boolean isBinary(File file) {
+	public static boolean isBinary(final File file) {
 		if (file == null) return false;
 		// heuristic: read the first up to 8000 bytes, and say that it is binary if
 		// it contains a NUL
 		try {
-			FileInputStream in = new FileInputStream(file);
+			final FileInputStream in = new FileInputStream(file);
 			int left = 8000;
-			byte[] buffer = new byte[left];
+			final byte[] buffer = new byte[left];
 			while (left > 0) {
-				int count = in.read(buffer, 0, left);
+				final int count = in.read(buffer, 0, left);
 				if (count < 0) break;
 				for (int i = 0; i < count; i++)
 					if (buffer[i] == 0) {
@@ -1600,7 +1616,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			in.close();
 			return false;
 		}
-		catch (IOException e) {
+		catch (final IOException e) {
 			return false;
 		}
 	}
@@ -1609,18 +1625,27 @@ public class TextEditor extends JFrame implements ActionListener,
 	 * Open a new tab with some content; the languageExtension is like ".java",
 	 * ".py", etc.
 	 */
-	public Tab newTab(String content, String language) {
-		Tab tab = open(null);
-		if (null != language && language.length() > 0) {
-			language = language.trim().toLowerCase();
-			if ('.' != language.charAt(0)) language = "." + language;
+	public Tab newTab(final String content, final String language) {
+		String lang = language;
+		final Tab tab = open(null);
+		if (null != lang && lang.length() > 0) {
+			lang = lang.trim().toLowerCase();
+
+			if ('.' != lang.charAt(0)) {
+				lang = "." + language;
+			}
+
 			tab.editorPane.setLanguage(scriptService.getLanguageByName(language));
 		}
-		if (null != content) tab.editorPane.setText(content);
+
+		if (null != content) {
+			tab.editorPane.setText(content);
+		}
+
 		return tab;
 	}
 
-	public Tab open(File file) {
+	public Tab open(final File file) {
 		if (isBinary(file)) {
 			// TODO!
 			throw new RuntimeException("TODO: open image using IJ2");
@@ -1629,17 +1654,17 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		try {
 			Tab tab = (tabbed.getTabCount() == 0) ? null : getTab();
-			boolean wasNew = tab != null && tab.editorPane.isNew();
+			final boolean wasNew = tab != null && tab.editorPane.isNew();
 			if (!wasNew) {
 				tab = new Tab();
 				context.inject(tab.editorPane);
 				tab.editorPane.loadPreferences();
 				addDefaultAccelerators(tab.editorPane);
 			}
-			synchronized (tab.editorPane) {
+			synchronized (tab.editorPane) { // tab is never null at this location.
 				tab.editorPane.open(file);
 				if (wasNew) {
-					int index = tabbed.getSelectedIndex() + tabsMenuTabsStart;
+					final int index = tabbed.getSelectedIndex() + tabsMenuTabsStart;
 					tabsMenu.getItem(index).setText(tab.editorPane.getFileName());
 				}
 				else {
@@ -1652,7 +1677,7 @@ public class TextEditor extends JFrame implements ActionListener,
 				try {
 					updateTabAndFontSize(true);
 				}
-				catch (NullPointerException e) {
+				catch (final NullPointerException e) {
 					/* ignore */
 				}
 			}
@@ -1660,11 +1685,11 @@ public class TextEditor extends JFrame implements ActionListener,
 
 			return tab;
 		}
-		catch (FileNotFoundException e) {
+		catch (final FileNotFoundException e) {
 			e.printStackTrace();
 			error("The file '" + file + "' was not found.");
 		}
-		catch (Exception e) {
+		catch (final Exception e) {
 			e.printStackTrace();
 			error("There was an error while opening '" + file + "': " + e);
 		}
@@ -1672,7 +1697,7 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public boolean saveAs() {
-		EditorPane editorPane = getEditorPane();
+		final EditorPane editorPane = getEditorPane();
 		File file = editorPane.getFile();
 		if (file == null) {
 			final File ijDir =
@@ -1684,12 +1709,12 @@ public class TextEditor extends JFrame implements ActionListener,
 		return saveAs(fileToSave.getAbsolutePath(), true);
 	}
 
-	public void saveAs(String path) {
+	public void saveAs(final String path) {
 		saveAs(path, true);
 	}
 
-	public boolean saveAs(String path, boolean askBeforeReplacing) {
-		File file = new File(path);
+	public boolean saveAs(final String path, final boolean askBeforeReplacing) {
+		final File file = new File(path);
 		if (file.exists() &&
 			askBeforeReplacing &&
 			JOptionPane.showConfirmDialog(this, "Do you want to replace " + path +
@@ -1701,33 +1726,33 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public boolean save() {
-		File file = getEditorPane().getFile();
+		final File file = getEditorPane().getFile();
 		if (file == null) return saveAs();
 		if (!write(file)) return false;
 		setTitle();
 		return true;
 	}
 
-	public boolean write(File file) {
+	public boolean write(final File file) {
 		try {
 			getEditorPane().write(file);
 			return true;
 		}
-		catch (IOException e) {
+		catch (final IOException e) {
 			error("Could not save " + file.getName());
 			e.printStackTrace();
 			return false;
 		}
 	}
 
-	public boolean makeJar(boolean includeSources) {
-		File file = getEditorPane().getFile();
+	public boolean makeJar(final boolean includeSources) {
+		final File file = getEditorPane().getFile();
 		if ((file == null || isCompiled()) && !handleUnsavedChanges(true)) {
 			return false;
 		}
 
 		String name = getEditorPane().getFileName();
-		String ext = FileUtils.getExtension(name);
+		final String ext = FileUtils.getExtension(name);
 		if (!"".equals(ext)) name = name.substring(0, name.length() - ext.length());
 		if (name.indexOf('_') < 0) name += "_";
 		name += ".jar";
@@ -1742,7 +1767,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			makeJar(selectedFile, includeSources);
 			return true;
 		}
-		catch (IOException e) {
+		catch (final IOException e) {
 			e.printStackTrace();
 			error("Could not write " + selectedFile + ": " + e.getMessage());
 			return false;
@@ -1773,17 +1798,19 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 	}
 
-	static void
-		getClasses(File directory, List<String> paths, List<String> names)
+	static void getClasses(final File directory, final List<String> paths,
+		final List<String> names)
 	{
 		getClasses(directory, paths, names, "");
 	}
 
-	static void getClasses(File directory, List<String> paths,
-		List<String> names, String prefix)
+	static void getClasses(final File directory, final List<String> paths,
+		final List<String> names, final String inPrefix)
 	{
+		String prefix = inPrefix;
+
 		if (!prefix.equals("")) prefix += "/";
-		for (File file : directory.listFiles())
+		for (final File file : directory.listFiles())
 			if (file.isDirectory()) getClasses(file, paths, names, prefix +
 				file.getName());
 			else {
@@ -1792,47 +1819,47 @@ public class TextEditor extends JFrame implements ActionListener,
 			}
 	}
 
-	static void writeJarEntry(JarOutputStream out, String name, byte[] buf)
-		throws IOException
+	static void writeJarEntry(final JarOutputStream out, final String name,
+		final byte[] buf) throws IOException
 	{
 		try {
-			JarEntry entry = new JarEntry(name);
+			final JarEntry entry = new JarEntry(name);
 			out.putNextEntry(entry);
 			out.write(buf, 0, buf.length);
 			out.closeEntry();
 		}
-		catch (ZipException e) {
+		catch (final ZipException e) {
 			e.printStackTrace();
 			throw new IOException(e.getMessage());
 		}
 	}
 
-	static byte[] readFile(String fileName) throws IOException {
-		File file = new File(fileName);
-		InputStream in = new FileInputStream(file);
-		byte[] buffer = new byte[(int) file.length()];
+	static byte[] readFile(final String fileName) throws IOException {
+		final File file = new File(fileName);
+		final InputStream in = new FileInputStream(file);
+		final byte[] buffer = new byte[(int) file.length()];
 		in.read(buffer);
 		in.close();
 		return buffer;
 	}
 
-	static void deleteRecursively(File directory) {
-		for (File file : directory.listFiles())
+	static void deleteRecursively(final File directory) {
+		for (final File file : directory.listFiles())
 			if (file.isDirectory()) deleteRecursively(file);
 			else file.delete();
 		directory.delete();
 	}
 
-	void setLanguage(ScriptLanguage language) {
+	void setLanguage(final ScriptLanguage language) {
 		setLanguage(language, false);
 	}
 
-	void setLanguage(ScriptLanguage language, boolean addHeader) {
+	void setLanguage(final ScriptLanguage language, final boolean addHeader) {
 		getEditorPane().setLanguage(language, addHeader);
 		updateTabAndFontSize(true);
 	}
 
-	void updateLanguageMenu(ScriptLanguage language) {
+	void updateLanguageMenu(final ScriptLanguage language) {
 		JMenuItem item = languageMenuItems.get(language);
 		if (item == null) item = noneLanguageItem;
 		if (!item.isSelected()) {
@@ -1852,14 +1879,14 @@ public class TextEditor extends JFrame implements ActionListener,
 		makeJar.setVisible(isCompileable);
 		makeJarWithSource.setVisible(isCompileable);
 
-		boolean isJava =
+		final boolean isJava =
 			language != null && language.getLanguageName().equals("Java");
 		addImport.setVisible(isJava);
 		removeUnusedImports.setVisible(isJava);
 		sortImports.setVisible(isJava);
 		openSourceForMenuItem.setVisible(isJava);
 
-		boolean isMacro =
+		final boolean isMacro =
 			language != null && language.getLanguageName().equals("ImageJ Macro");
 		openMacroFunctions.setVisible(isMacro);
 		openSourceForClass.setVisible(!isMacro);
@@ -1869,29 +1896,30 @@ public class TextEditor extends JFrame implements ActionListener,
 		nextError.setVisible(!isMacro && isRunnable);
 		previousError.setVisible(!isMacro && isRunnable);
 
-		boolean isInGit = getEditorPane().getGitDirectory() != null;
+		final boolean isInGit = getEditorPane().getGitDirectory() != null;
 		gitMenu.setVisible(isInGit);
 
 		updateTabAndFontSize(false);
 	}
 
-	public void updateTabAndFontSize(boolean setByLanguage) {
-		EditorPane pane = getEditorPane();
+	public void updateTabAndFontSize(final boolean setByLanguage) {
+		final EditorPane pane = getEditorPane();
 		if (pane.getCurrentLanguage() == null) return;
 
 		if (setByLanguage) {
 			if (pane.getCurrentLanguage().getLanguageName().equals("Python")) {
 				pane.setTabSize(4);
-			} else {
+			}
+			else {
 				// set tab size to current preferences.
 				pane.resetTabSize();
 			}
 		}
 
-		int tabSize = pane.getTabSize();
+		final int tabSize = pane.getTabSize();
 		boolean defaultSize = false;
 		for (int i = 0; i < tabSizeMenu.getItemCount(); i++) {
-			JMenuItem item = tabSizeMenu.getItem(i);
+			final JMenuItem item = tabSizeMenu.getItem(i);
 			if (item == chooseTabSize) {
 				item.setSelected(!defaultSize);
 				item.setText("Other" + (defaultSize ? "" : " (" + tabSize + ")") +
@@ -1902,10 +1930,10 @@ public class TextEditor extends JFrame implements ActionListener,
 				defaultSize = true;
 			}
 		}
-		int fontSize = (int) pane.getFontSize();
+		final int fontSize = (int) pane.getFontSize();
 		defaultSize = false;
 		for (int i = 0; i < fontSizeMenu.getItemCount(); i++) {
-			JMenuItem item = fontSizeMenu.getItem(i);
+			final JMenuItem item = fontSizeMenu.getItem(i);
 			if (item == chooseFontSize) {
 				item.setSelected(!defaultSize);
 				item.setText("Other" + (defaultSize ? "" : " (" + fontSize + ")") +
@@ -1923,11 +1951,11 @@ public class TextEditor extends JFrame implements ActionListener,
 		tabsEmulated.setState(pane.getTabsEmulated());
 	}
 
-	public void setFileName(String baseName) {
+	public void setFileName(final String baseName) {
 		getEditorPane().setFileName(baseName);
 	}
 
-	public void setFileName(File file) {
+	public void setFileName(final File file) {
 		getEditorPane().setFileName(file);
 	}
 
@@ -1952,16 +1980,16 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	@Override
-	public synchronized void setTitle(String title) {
+	public synchronized void setTitle(final String title) {
 		super.setTitle(title);
-		int index = tabsMenuTabsStart + tabbed.getSelectedIndex();
+		final int index = tabsMenuTabsStart + tabbed.getSelectedIndex();
 		if (index < tabsMenu.getItemCount()) {
-			JMenuItem item = tabsMenu.getItem(index);
+			final JMenuItem item = tabsMenu.getItem(index);
 			if (item != null) item.setText(title);
 		}
 	}
 
-	private ArrayList<Executer> executingTasks = new ArrayList<Executer>();
+	private final ArrayList<Executer> executingTasks = new ArrayList<Executer>();
 
 	/**
 	 * Generic Thread that keeps a starting time stamp, sets the priority to
@@ -1998,12 +2026,12 @@ public class TextEditor extends JFrame implements ActionListener,
 							if (isInterrupted()) break;
 							try {
 								Thread.sleep(500);
-								List<Thread> ts = getAllThreads();
+								final List<Thread> ts = getAllThreads();
 								activeCount = ts.size();
 								if (activeCount <= 1) break;
 								log.debug("Waiting for " + ts.size() + " threads to die");
 								int count_zSelector = 0;
-								for (Thread t : ts) {
+								for (final Thread t : ts) {
 									if (t.getName().equals("zSelector")) {
 										count_zSelector++;
 									}
@@ -2014,10 +2042,12 @@ public class TextEditor extends JFrame implements ActionListener,
 									break;
 								}
 							}
-							catch (InterruptedException ie) {}
+							catch (final InterruptedException ie) {
+								/* ignore */
+							}
 						}
 					}
-					catch (Throwable t) {
+					catch (final Throwable t) {
 						handleException(t);
 					}
 					finally {
@@ -2026,7 +2056,7 @@ public class TextEditor extends JFrame implements ActionListener,
 							if (null != output) output.shutdown();
 							if (null != errors) errors.shutdown();
 						}
-						catch (Exception e) {
+						catch (final Exception e) {
 							handleException(e);
 						}
 						// Leave kill menu item enabled if other tasks are running
@@ -2042,23 +2072,23 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		/** Fetch a list of all threads from all thread subgroups, recursively. */
 		List<Thread> getAllThreads() {
-			ArrayList<Thread> threads = new ArrayList<Thread>();
+			final ArrayList<Thread> threads = new ArrayList<Thread>();
 			// From all subgroups:
-			ThreadGroup[] tgs = new ThreadGroup[activeGroupCount() * 2 + 100];
+			final ThreadGroup[] tgs = new ThreadGroup[activeGroupCount() * 2 + 100];
 			this.enumerate(tgs, true);
-			for (ThreadGroup tg : tgs) {
+			for (final ThreadGroup tg : tgs) {
 				if (null == tg) continue;
-				Thread[] ts = new Thread[tg.activeCount() * 2 + 100];
+				final Thread[] ts = new Thread[tg.activeCount() * 2 + 100];
 				tg.enumerate(ts);
-				for (Thread t : ts) {
+				for (final Thread t : ts) {
 					if (null == t) continue;
 					threads.add(t);
 				}
 			}
 			// And from this group:
-			Thread[] ts = new Thread[activeCount() * 2 + 100];
+			final Thread[] ts = new Thread[activeCount() * 2 + 100];
 			this.enumerate(ts);
-			for (Thread t : ts) {
+			for (final Thread t : ts) {
 				if (null == t) continue;
 				threads.add(t);
 			}
@@ -2076,16 +2106,16 @@ public class TextEditor extends JFrame implements ActionListener,
 				if (null != output) output.shutdownNow();
 				if (null != errors) errors.shutdownNow();
 			}
-			catch (Exception e) {
+			catch (final Exception e) {
 				e.printStackTrace();
 			}
-			for (Thread thread : getAllThreads()) {
+			for (final Thread thread : getAllThreads()) {
 				try {
 					thread.interrupt();
 					Thread.yield(); // give it a chance
 					thread.stop();
 				}
-				catch (Throwable t) {
+				catch (final Throwable t) {
 					t.printStackTrace();
 				}
 			}
@@ -2104,9 +2134,9 @@ public class TextEditor extends JFrame implements ActionListener,
 		return executingTasks;
 	}
 
-	public void kill(Executer executer) {
+	public void kill(final Executer executer) {
 		for (int i = 0; i < tabbed.getTabCount(); i++) {
-			Tab tab = (Tab) tabbed.getComponentAt(i);
+			final Tab tab = (Tab) tabbed.getComponentAt(i);
 			if (executer == tab.executer) {
 				tab.kill();
 				break;
@@ -2149,11 +2179,11 @@ public class TextEditor extends JFrame implements ActionListener,
 		markCompileStart();
 
 		try {
-			Tab tab = getTab();
+			final Tab tab = getTab();
 			tab.showOutput();
 			tab.execute(selectionOnly);
 		}
-		catch (Throwable t) {
+		catch (final Throwable t) {
 			t.printStackTrace();
 		}
 	}
@@ -2174,14 +2204,14 @@ public class TextEditor extends JFrame implements ActionListener,
 				Reader reader = null;
 				try {
 					reader =
-						evalScript(getEditorPane().getFile().getPath(), new FileReader(file),
-							output, errors);
+						evalScript(getEditorPane().getFile().getPath(),
+							new FileReader(file), output, errors);
 
 					output.flush();
 					errors.flush();
 					markCompileEnd();
 				}
-				catch (Throwable e) {
+				catch (final Throwable e) {
 					handleException(e);
 				}
 				finally {
@@ -2220,7 +2250,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 	}
 
-	public String getSelectedTextOrAsk(String label) {
+	public String getSelectedTextOrAsk(final String label) {
 		String selection = getTextArea().getSelectedText();
 		if (selection == null || selection.indexOf('\n') >= 0) {
 			selection =
@@ -2237,8 +2267,8 @@ public class TextEditor extends JFrame implements ActionListener,
 		return className;
 	}
 
-	protected static void append(JTextArea textArea, String text) {
-		int length = textArea.getDocument().getLength();
+	protected static void append(final JTextArea textArea, final String text) {
+		final int length = textArea.getDocument().getLength();
 		textArea.insert(text, length);
 		textArea.setCaretPosition(length);
 	}
@@ -2246,16 +2276,16 @@ public class TextEditor extends JFrame implements ActionListener,
 	public void markCompileStart() {
 		errorHandler = null;
 
-		String started =
+		final String started =
 			"Started " + getEditorPane().getFileName() + " at " + new Date() + "\n";
-		int offset = errorScreen.getDocument().getLength();
+		final int offset = errorScreen.getDocument().getLength();
 		append(errorScreen, started);
 		append(getTab().screen, started);
 		compileStartOffset = errorScreen.getDocument().getLength();
 		try {
 			compileStartPosition = errorScreen.getDocument().createPosition(offset);
 		}
-		catch (BadLocationException e) {
+		catch (final BadLocationException e) {
 			handleException(e);
 		}
 		ExceptionHandler.addThread(Thread.currentThread(), this);
@@ -2275,7 +2305,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 	}
 
-	public boolean nextError(boolean forward) {
+	public boolean nextError(final boolean forward) {
 		if (errorHandler != null && errorHandler.nextError(forward)) try {
 			File file = new File(errorHandler.getPath());
 			if (!file.isAbsolute()) file = getFileForBasename(file.getName());
@@ -2285,17 +2315,19 @@ public class TextEditor extends JFrame implements ActionListener,
 			errorScreen.invalidate();
 			return true;
 		}
-		catch (Exception e) {
+		catch (final Exception e) {
 			handleException(e);
 		}
 		return false;
 	}
 
-	public void switchTo(String path, int lineNumber) throws IOException {
+	public void switchTo(final String path, final int lineNumber)
+		throws IOException
+	{
 		switchTo(new File(path).getCanonicalFile(), lineNumber);
 	}
 
-	public void switchTo(File file, final int lineNumber) {
+	public void switchTo(final File file, final int lineNumber) {
 		if (!editorPaneContainsFile(getEditorPane(), file)) switchTo(file);
 		SwingUtilities.invokeLater(new Runnable() {
 
@@ -2304,14 +2336,14 @@ public class TextEditor extends JFrame implements ActionListener,
 				try {
 					gotoLine(lineNumber);
 				}
-				catch (BadLocationException e) {
+				catch (final BadLocationException e) {
 					// ignore
 				}
 			}
 		});
 	}
 
-	public void switchTo(File file) {
+	public void switchTo(final File file) {
 		for (int i = 0; i < tabbed.getTabCount(); i++)
 			if (editorPaneContainsFile(getEditorPane(i), file)) {
 				switchTo(i);
@@ -2320,14 +2352,14 @@ public class TextEditor extends JFrame implements ActionListener,
 		open(file);
 	}
 
-	public void switchTo(int index) {
+	public void switchTo(final int index) {
 		if (index == tabbed.getSelectedIndex()) return;
 		tabbed.setSelectedIndex(index);
 	}
 
-	protected void switchTabRelative(int delta) {
+	protected void switchTabRelative(final int delta) {
 		int index = tabbed.getSelectedIndex();
-		int count = tabbed.getTabCount();
+		final int count = tabbed.getTabCount();
 		index = ((index + delta) % count);
 		if (index < 0) index += count;
 		switchTo(index);
@@ -2340,12 +2372,13 @@ public class TextEditor extends JFrame implements ActionListener,
 		tabsMenu.remove(index);
 	}
 
-	boolean editorPaneContainsFile(EditorPane editorPane, File file) {
+	boolean editorPaneContainsFile(final EditorPane editorPane, final File file) {
 		try {
-			return file != null && editorPane != null && editorPane.getFile() != null &&
+			return file != null && editorPane != null &&
+				editorPane.getFile() != null &&
 				file.getCanonicalFile().equals(editorPane.getFile().getCanonicalFile());
 		}
-		catch (IOException e) {
+		catch (final IOException e) {
 			return false;
 		}
 	}
@@ -2354,7 +2387,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		return getEditorPane().getFile();
 	}
 
-	public File getFileForBasename(String baseName) {
+	public File getFileForBasename(final String baseName) {
 		File file = getFile();
 		if (file != null && file.getName().equals(baseName)) return file;
 		for (int i = 0; i < tabbed.getTabCount(); i++) {
@@ -2365,42 +2398,47 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public void addImport(String className) {
-		if (className == null) className = getSelectedClassNameOrAsk();
-		if (className != null) new TokenFunctions(getTextArea())
-			.addImport(className.trim());
+		if (className == null) {
+			className = getSelectedClassNameOrAsk();
+		}
+		if (className != null) {
+			new TokenFunctions(getTextArea()).addImport(className.trim());
+		}
 	}
 
-	public void openHelp(String className) {
+	public void openHelp(final String className) {
 		openHelp(className, true);
 	}
 
-	public void openHelp(String className, boolean withFrames) {
-		if (className == null) className = getSelectedClassNameOrAsk();
+	public void openHelp(String className, final boolean withFrames) {
+		if (className == null) {
+			className = getSelectedClassNameOrAsk();
+		}
 	}
 
 	public void extractSourceJar() {
-		File file = openWithDialog(null);
+		final File file = openWithDialog(null);
 		if (file != null) extractSourceJar(file);
 	}
 
-	public void extractSourceJar(File file) {
+	public void extractSourceJar(final File file) {
 		try {
-			FileFunctions functions = new FileFunctions(this);
+			final FileFunctions functions = new FileFunctions(this);
 			final File workspace =
 				uiService.chooseFile(new File(System.getProperty("user.home")),
 					FileWidget.DIRECTORY_STYLE);
 			if (workspace == null) return;
-			List<String> paths =
+			final List<String> paths =
 				functions.extractSourceJar(file.getAbsolutePath(), workspace);
-			for (String path : paths)
+			for (final String path : paths)
 				if (!functions.isBinaryFile(path)) {
 					open(new File(path));
-					EditorPane pane = getEditorPane();
+					final EditorPane pane = getEditorPane();
 					new TokenFunctions(pane).removeTrailingWhitespace();
 					if (pane.fileChanged()) save();
 				}
 		}
-		catch (IOException e) {
+		catch (final IOException e) {
 			error("There was a problem opening " + file + ": " + e.getMessage());
 		}
 	}
@@ -2416,30 +2454,32 @@ public class TextEditor extends JFrame implements ActionListener,
 	 * @param message The text to write
 	 */
 	public void write(String message) {
-		Tab tab = getTab();
+		final Tab tab = getTab();
 		if (!message.endsWith("\n")) message += "\n";
 		tab.screen.insert(message, tab.screen.getDocument().getLength());
 	}
 
 	public void writeError(String message) {
-		Tab tab = getTab();
+		final Tab tab = getTab();
 		tab.showErrors();
 		if (!message.endsWith("\n")) message += "\n";
 		errorScreen.insert(message, errorScreen.getDocument().getLength());
 	}
 
-	protected void error(String message) {
+	protected void error(final String message) {
 		JOptionPane.showMessageDialog(this, message);
 	}
 
-	protected void handleException(Throwable e) {
+	protected void handleException(final Throwable e) {
 		handleException(e, errorScreen);
 		getTab().showErrors();
 	}
 
-	public static void handleException(Throwable e, JTextArea textArea) {
+	public static void
+		handleException(final Throwable e, final JTextArea textArea)
+	{
 		final CharArrayWriter writer = new CharArrayWriter();
-		PrintWriter out = new PrintWriter(writer);
+		final PrintWriter out = new PrintWriter(writer);
 		e.printStackTrace(out);
 		for (Throwable cause = e.getCause(); cause != null; cause =
 			cause.getCause())
@@ -2453,12 +2493,12 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	/**
 	 * Removes invalid characters, shows a dialog.
-	 * 
+	 *
 	 * @return The amount of invalid characters found.
 	 */
 	public int zapGremlins() {
-		int count = getEditorPane().zapGremlins();
-		String msg =
+		final int count = getEditorPane().zapGremlins();
+		final String msg =
 			count > 0 ? "Zap Gremlins converted " + count +
 				" invalid characters to spaces" : "No invalid characters found!";
 		JOptionPane.showMessageDialog(this, msg);
@@ -2499,10 +2539,10 @@ public class TextEditor extends JFrame implements ActionListener,
 		try {
 			moduleService.run(module, true).get();
 		}
-		catch (InterruptedException e) {
+		catch (final InterruptedException e) {
 			error("Interrupted");
 		}
-		catch (ExecutionException e) {
+		catch (final ExecutionException e) {
 			log.error(e);
 		}
 		return reader;
@@ -2512,7 +2552,7 @@ public class TextEditor extends JFrame implements ActionListener,
 	public boolean confirmClose() {
 		while (tabbed.getTabCount() > 0) {
 			if (!handleUnsavedChanges()) return false;
-			int index = tabbed.getSelectedIndex();
+			final int index = tabbed.getSelectedIndex();
 			removeTab(index);
 		}
 		return true;

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -726,7 +726,7 @@ public class TextEditor extends JFrame implements ActionListener,
 	 *
 	 * @return The currently selected tab. Never null.
 	 */
-	public Tab getTab() {
+	public TextEditorTab getTab() {
 		final int index = tabbed.getSelectedIndex();
 		if (index < 0) {
 			// should not happen, but safety first.
@@ -737,7 +737,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 			tabbed.setSelectedIndex(0);
 		}
-		return (Tab) tabbed.getComponentAt(index);
+		return (TextEditorTab) tabbed.getComponentAt(index);
 	}
 
 	/**
@@ -746,8 +746,8 @@ public class TextEditor extends JFrame implements ActionListener,
 	 * @param index the index of the tab.
 	 * @return the {@link Tab} at given index or <code>null</code>.
 	 */
-	public Tab getTab(final int index) {
-		return (Tab) tabbed.getComponentAt(index);
+	public TextEditorTab getTab(final int index) {
+		return (TextEditorTab) tabbed.getComponentAt(index);
 	}
 
 	/**
@@ -1286,278 +1286,6 @@ public class TextEditor extends JFrame implements ActionListener,
 		return false;
 	}
 
-	public class Tab extends JSplitPane {
-
-		protected final EditorPane editorPane = new EditorPane(TextEditor.this);
-		protected final JTextArea screen = new JTextArea();
-		protected final JScrollPane scroll;
-		protected boolean showingErrors;
-		private Executer executer;
-		private final JButton runit, killit, toggleErrors;
-
-		public Tab() {
-			super(JSplitPane.VERTICAL_SPLIT);
-			super.setResizeWeight(350.0 / 430.0);
-
-			screen.setEditable(false);
-			screen.setLineWrap(true);
-			screen.setFont(new Font("Courier", Font.PLAIN, 12));
-
-			final JPanel bottom = new JPanel();
-			bottom.setLayout(new GridBagLayout());
-			final GridBagConstraints bc = new GridBagConstraints();
-
-			bc.gridx = 0;
-			bc.gridy = 0;
-			bc.weightx = 0;
-			bc.weighty = 0;
-			bc.anchor = GridBagConstraints.NORTHWEST;
-			bc.fill = GridBagConstraints.NONE;
-			runit = new JButton("Run");
-			runit.addActionListener(new ActionListener() {
-
-				@Override
-				public void actionPerformed(final ActionEvent ae) {
-					runText();
-				}
-			});
-			bottom.add(runit, bc);
-
-			bc.gridx = 1;
-			killit = new JButton("Kill");
-			killit.setEnabled(false);
-			killit.addActionListener(new ActionListener() {
-
-				@Override
-				public void actionPerformed(final ActionEvent ae) {
-					kill();
-				}
-			});
-			bottom.add(killit, bc);
-
-			bc.gridx = 2;
-			bc.fill = GridBagConstraints.HORIZONTAL;
-			bc.weightx = 1;
-			bottom.add(new JPanel(), bc);
-
-			bc.gridx = 3;
-			bc.fill = GridBagConstraints.NONE;
-			bc.weightx = 0;
-			bc.anchor = GridBagConstraints.NORTHEAST;
-			toggleErrors = new JButton("Show Errors");
-			toggleErrors.addActionListener(new ActionListener() {
-
-				@Override
-				public void actionPerformed(final ActionEvent e) {
-					toggleErrors();
-				}
-			});
-			bottom.add(toggleErrors, bc);
-
-			bc.gridx = 4;
-			bc.fill = GridBagConstraints.NONE;
-			bc.weightx = 0;
-			bc.anchor = GridBagConstraints.NORTHEAST;
-			final JButton clear = new JButton("Clear");
-			clear.addActionListener(new ActionListener() {
-
-				@Override
-				public void actionPerformed(final ActionEvent ae) {
-					if (showingErrors) errorScreen.setText("");
-					else screen.setText("");
-				}
-			});
-			bottom.add(clear, bc);
-
-			bc.gridx = 0;
-			bc.gridy = 1;
-			bc.anchor = GridBagConstraints.NORTHWEST;
-			bc.fill = GridBagConstraints.BOTH;
-			bc.weightx = 1;
-			bc.weighty = 1;
-			bc.gridwidth = 5;
-			screen.setEditable(false);
-			screen.setLineWrap(true);
-			final Font font = new Font("Courier", Font.PLAIN, 12);
-			screen.setFont(font);
-			scroll = new JScrollPane(screen);
-			scroll.setPreferredSize(new Dimension(600, 80));
-			bottom.add(scroll, bc);
-
-			super.setTopComponent(editorPane.wrappedInScrollbars());
-			super.setBottomComponent(bottom);
-		}
-
-		/** Invoke in the context of the event dispatch thread. */
-		private void prepare() {
-			editorPane.setEditable(false);
-			runit.setEnabled(false);
-			killit.setEnabled(true);
-		}
-
-		private void restore() {
-			SwingUtilities.invokeLater(new Runnable() {
-
-				@Override
-				public void run() {
-					editorPane.setEditable(true);
-					runit.setEnabled(true);
-					killit.setEnabled(false);
-					executer = null;
-				}
-			});
-		}
-
-		public void toggleErrors() {
-			showingErrors = !showingErrors;
-			if (showingErrors) {
-				toggleErrors.setText("Show Output");
-				scroll.setViewportView(errorScreen);
-			}
-			else {
-				toggleErrors.setText("Show Errors");
-				scroll.setViewportView(screen);
-			}
-		}
-
-		public void showErrors() {
-			if (!showingErrors) toggleErrors();
-			else if (scroll.getViewport().getView() == null) scroll
-				.setViewportView(errorScreen);
-		}
-
-		public void showOutput() {
-			if (showingErrors) toggleErrors();
-		}
-
-		public JTextArea getScreen() {
-			return showingErrors ? errorScreen : screen;
-		}
-
-		boolean isExecuting() {
-			return null != executer;
-		}
-
-		String getTitle() {
-			return (editorPane.fileChanged() ? "*" : "") + editorPane.getFileName() +
-				(isExecuting() ? " (Running)" : "");
-		}
-
-		/** Invoke in the context of the event dispatch thread. */
-		private void execute(final boolean selectionOnly) throws IOException {
-			prepare();
-			final JTextAreaWriter output =
-				new JTextAreaWriter(this.screen, TextEditor.this.log);
-			final JTextAreaWriter errors = new JTextAreaWriter(errorScreen, log);
-			final File file = getEditorPane().getFile();
-			// Pipe current text into the runScript:
-			final PipedInputStream pi = new PipedInputStream();
-			final PipedOutputStream po = new PipedOutputStream(pi);
-			// The Executer creates a Thread that
-			// does the reading from PipedInputStream
-			this.executer = new TextEditor.Executer(output, errors) {
-
-				@Override
-				public void execute() {
-					try {
-						evalScript(file == null ? getEditorPane().getFileName() : file
-							.getAbsolutePath(), new InputStreamReader(pi), output, errors);
-						output.flush();
-						errors.flush();
-						markCompileEnd();
-					}
-					catch (final Throwable t) {
-						output.flush();
-						errors.flush();
-						if (t instanceof ScriptException && t.getCause() != null &&
-							t.getCause().getClass().getName().endsWith("CompileError"))
-						{
-							errorScreen.append("Compilation failed");
-							showErrors();
-						}
-						else {
-							handleException(t);
-						}
-					}
-					finally {
-						restore();
-					}
-				}
-			};
-			// Write into PipedOutputStream
-			// from another Thread
-			try {
-				final String text;
-				if (selectionOnly) {
-					final String selected = editorPane.getSelectedText();
-					if (selected == null) {
-						error("Selection required!");
-						text = null;
-					}
-					else text = selected + "\n"; // Ensure code blocks are terminated
-				}
-				else {
-					text = editorPane.getText();
-				}
-				new Thread() {
-
-					{
-						setPriority(Thread.NORM_PRIORITY);
-					}
-
-					@Override
-					public void run() {
-						final PrintWriter pw = new PrintWriter(po);
-						pw.write(text);
-						pw.flush(); // will lock and wait in some cases
-						try {
-							po.close();
-						}
-						catch (final Throwable tt) {
-							tt.printStackTrace();
-						}
-						pw.close();
-					}
-				}.start();
-			}
-			catch (final Throwable t) {
-				t.printStackTrace();
-			}
-			finally {
-				// Re-enable when all text to send has been sent
-				editorPane.setEditable(true);
-			}
-		}
-
-		protected void kill() {
-			if (null == executer) return;
-			// Graceful attempt:
-			executer.interrupt();
-			// Give it 3 seconds. Then, stop it.
-			final long now = System.currentTimeMillis();
-			new Thread() {
-
-				{
-					setPriority(Thread.NORM_PRIORITY);
-				}
-
-				@Override
-				public void run() {
-					while (System.currentTimeMillis() - now < 3000)
-						try {
-							Thread.sleep(100);
-						}
-						catch (final InterruptedException e) {
-							/* ignore */
-						}
-					if (null != executer) executer.obliterate();
-					restore();
-
-				}
-			}.start();
-		}
-	}
-
 	public static boolean isBinary(final File file) {
 		if (file == null) return false;
 		// heuristic: read the first up to 8000 bytes, and say that it is binary if
@@ -1588,9 +1316,9 @@ public class TextEditor extends JFrame implements ActionListener,
 	 * Open a new tab with some content; the languageExtension is like ".java",
 	 * ".py", etc.
 	 */
-	public Tab newTab(final String content, final String language) {
+	public TextEditorTab newTab(final String content, final String language) {
 		String lang = language;
-		final Tab tab = open(null);
+		final TextEditorTab tab = open(null);
 		if (null != lang && lang.length() > 0) {
 			lang = lang.trim().toLowerCase();
 
@@ -1608,7 +1336,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		return tab;
 	}
 
-	public Tab open(final File file) {
+	public TextEditorTab open(final File file) {
 		if (isBinary(file)) {
 			// TODO!
 			throw new RuntimeException("TODO: open image using IJ2");
@@ -1616,10 +1344,10 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 
 		try {
-			Tab tab = (tabbed.getTabCount() == 0) ? null : getTab();
+			TextEditorTab tab = (tabbed.getTabCount() == 0) ? null : getTab();
 			final boolean wasNew = tab != null && tab.editorPane.isNew();
 			if (!wasNew) {
-				tab = new Tab();
+				tab = new TextEditorTab(this);
 				context.inject(tab.editorPane);
 				tab.editorPane.loadPreferences();
 				addDefaultAccelerators(tab.editorPane);
@@ -1923,7 +1651,7 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	synchronized void setTitle() {
-		final Tab tab = getTab();
+		final TextEditorTab tab = getTab();
 
 		final boolean fileChanged = tab.editorPane.fileChanged();
 		final String fileName = tab.editorPane.getFileName();
@@ -1937,7 +1665,7 @@ public class TextEditor extends JFrame implements ActionListener,
 				setTitle(title); // to the main window
 				// Update all tabs: could have changed
 				for (int i = 0; i < tabbed.getTabCount(); i++)
-					tabbed.setTitleAt(i, ((Tab) tabbed.getComponentAt(i)).getTitle());
+					tabbed.setTitleAt(i, ((TextEditorTab) tabbed.getComponentAt(i)).getTitle());
 			}
 		});
 	}
@@ -2099,8 +1827,8 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	public void kill(final Executer executer) {
 		for (int i = 0; i < tabbed.getTabCount(); i++) {
-			final Tab tab = (Tab) tabbed.getComponentAt(i);
-			if (executer == tab.executer) {
+			final TextEditorTab tab = (TextEditorTab) tabbed.getComponentAt(i);
+			if (executer == tab.getExecuter()) {
 				tab.kill();
 				break;
 			}
@@ -2142,12 +1870,101 @@ public class TextEditor extends JFrame implements ActionListener,
 		markCompileStart();
 
 		try {
-			final Tab tab = getTab();
+			final TextEditorTab tab = getTab();
 			tab.showOutput();
-			tab.execute(selectionOnly);
+			execute(selectionOnly);
 		}
 		catch (final Throwable t) {
 			t.printStackTrace();
+		}
+	}
+	
+	/** Invoke in the context of the event dispatch thread. */
+	private void execute(final boolean selectionOnly) throws IOException {
+		final TextEditorTab tab = getTab();
+		
+		tab.prepare();
+		
+		final JTextAreaWriter output =
+			new JTextAreaWriter(tab.screen, log);
+		final JTextAreaWriter errors = new JTextAreaWriter(errorScreen, log);
+		final File file = getEditorPane().getFile();
+		// Pipe current text into the runScript:
+		final PipedInputStream pi = new PipedInputStream();
+		final PipedOutputStream po = new PipedOutputStream(pi);
+		// The Executer creates a Thread that
+		// does the reading from PipedInputStream
+		tab.setExecutor(new Executer(output, errors) {
+
+			@Override
+			public void execute() {
+				try {
+					evalScript(file == null ? getEditorPane().getFileName() : file
+						.getAbsolutePath(), new InputStreamReader(pi), output, errors);
+					output.flush();
+					errors.flush();
+					markCompileEnd();
+				}
+				catch (final Throwable t) {
+					output.flush();
+					errors.flush();
+					if (t instanceof ScriptException && t.getCause() != null &&
+						t.getCause().getClass().getName().endsWith("CompileError"))
+					{
+						errorScreen.append("Compilation failed");
+						tab.showErrors();
+					}
+					else {
+						handleException(t);
+					}
+				}
+				finally {
+					tab.restore();
+				}
+			}
+		});
+		// Write into PipedOutputStream
+		// from another Thread
+		try {
+			final String text;
+			if (selectionOnly) {
+				final String selected = tab.getEditorPane().getSelectedText();
+				if (selected == null) {
+					error("Selection required!");
+					text = null;
+				}
+				else text = selected + "\n"; // Ensure code blocks are terminated
+			}
+			else {
+				text = tab.getEditorPane().getText();
+			}
+			new Thread() {
+
+				{
+					setPriority(Thread.NORM_PRIORITY);
+				}
+
+				@Override
+				public void run() {
+					final PrintWriter pw = new PrintWriter(po);
+					pw.write(text);
+					pw.flush(); // will lock and wait in some cases
+					try {
+						po.close();
+					}
+					catch (final Throwable tt) {
+						tt.printStackTrace();
+					}
+					pw.close();
+				}
+			}.start();
+		}
+		catch (final Throwable t) {
+			t.printStackTrace();
+		}
+		finally {
+			// Re-enable when all text to send has been sent
+			tab.getEditorPane().setEditable(true);
 		}
 	}
 
@@ -2417,13 +2234,13 @@ public class TextEditor extends JFrame implements ActionListener,
 	 * @param message The text to write
 	 */
 	public void write(String message) {
-		final Tab tab = getTab();
+		final TextEditorTab tab = getTab();
 		if (!message.endsWith("\n")) message += "\n";
 		tab.screen.insert(message, tab.screen.getDocument().getLength());
 	}
 
 	public void writeError(String message) {
-		final Tab tab = getTab();
+		final TextEditorTab tab = getTab();
 		tab.showErrors();
 		if (!message.endsWith("\n")) message += "\n";
 		errorScreen.insert(message, errorScreen.getDocument().getLength());

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -1929,6 +1929,15 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	synchronized void setTitle() {
+		/* 
+		 * This method might still get called after all tabs have been closed because
+		 * the ScriptEditor is being shutdown and we saved our changes via the dialog.
+		 * Therefore, we need to check if there actually is a tab to set the title for.
+		 */
+		if (tabbed.getTabCount() == 0) {
+			return;
+		}
+		
 		final Tab tab = getTab();
 
 		final boolean fileChanged = tab.editorPane.fileChanged();

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -111,8 +111,6 @@ import net.imagej.ui.swing.script.commands.KillScript;
 import org.fife.ui.rsyntaxtextarea.AbstractTokenMakerFactory;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.TokenMakerFactory;
-import org.fife.ui.rsyntaxtextarea.modes.JavaScriptTokenMaker;
-import org.fife.ui.rsyntaxtextarea.modes.JavaTokenMaker;
 import org.scijava.Context;
 import org.scijava.command.CommandService;
 import org.scijava.event.ContextDisposingEvent;
@@ -123,7 +121,6 @@ import org.scijava.module.ModuleException;
 import org.scijava.module.ModuleService;
 import org.scijava.platform.PlatformService;
 import org.scijava.plugin.Parameter;
-import org.scijava.plugin.Plugin;
 import org.scijava.plugin.PluginInfo;
 import org.scijava.plugin.PluginService;
 import org.scijava.plugins.scripting.java.JavaEngine;
@@ -680,34 +677,6 @@ public class TextEditor extends JFrame implements ActionListener,
 	 */
 	public static void addTemplatePath(final String path) {
 		TEMPLATE_PATHS.add(path);
-	}
-
-	@Plugin(type = SyntaxHighlighter.class, label = "ecmascript")
-	public static class ECMAScriptHighlighter extends JavaScriptTokenMaker
-		implements SyntaxHighlighter
-	{
-		// Everything implemented in JavaScriptTokenMaker
-	}
-
-	@Plugin(type = SyntaxHighlighter.class, label = "matlab")
-	public static class MatlabHighlighter extends MatlabTokenMaker implements
-		SyntaxHighlighter
-	{
-		// Everything implemented in MatlabTokenMaker
-	}
-
-	@Plugin(type = SyntaxHighlighter.class, label = "ij1-macro")
-	public static class IJ1MacroHighlighter extends ImageJMacroTokenMaker
-		implements SyntaxHighlighter
-	{
-		// Everything implemented in ImageJMacroTokenMaker
-	}
-
-	@Plugin(type = SyntaxHighlighter.class, label = "beanshell")
-	public static class BeanshellHighlighter extends JavaTokenMaker implements
-		SyntaxHighlighter
-	{
-		// Everything implemented in JavaTokenMaker
 	}
 
 	@SuppressWarnings("unused")

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -600,8 +600,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 			@Override
 			public void windowGainedFocus(final WindowEvent e) {
-				final EditorPane editorPane = getEditorPane();
-				editorPane.checkForOutsideChanges();
+				checkForOutsideChanges();
 			}
 		});
 
@@ -663,6 +662,19 @@ public class TextEditor extends JFrame implements ActionListener,
 			catch (final Throwable t) {
 				log.warn("Could not register " + info.getLabel(), t);
 			}
+	}
+
+	/**
+	 * Check whether the file was edited outside of this {@link EditorPane} and
+	 * ask the user whether to reload.
+	 */
+	public void checkForOutsideChanges() {
+		EditorPane editorPane = getEditorPane();
+		if (editorPane.wasChangedOutside()) {
+			reload("The file " + editorPane.getFile().getName() +
+				"was changed outside of the editor");
+		}
+
 	}
 
 	/**
@@ -1203,10 +1215,10 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 		final EditorPane editorPane = getEditorPane(index);
 		editorPane.requestFocus();
-		editorPane.checkForOutsideChanges();
+		checkForOutsideChanges();
 
 		toggleWhiteSpaceLabeling.setSelected(editorPane.isWhitespaceVisible());
-		
+
 		editorPane.setLanguageByFileName(editorPane.getFileName());
 		updateLanguageMenu(editorPane.getCurrentLanguage());
 
@@ -2362,11 +2374,13 @@ public class TextEditor extends JFrame implements ActionListener,
 	@Override
 	public void insertUpdate(DocumentEvent e) {
 		setTitle();
+		checkForOutsideChanges();
 	}
 
 	@Override
 	public void removeUpdate(DocumentEvent e) {
 		setTitle();
+		checkForOutsideChanges();
 	}
 
 	@Override

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -1206,15 +1206,9 @@ public class TextEditor extends JFrame implements ActionListener,
 		editorPane.requestFocus();
 		setTitle();
 		editorPane.checkForOutsideChanges();
-		SwingUtilities.invokeLater(new Runnable() {
-
-			@Override
-			public void run() {
-				editorPane.setLanguageByFileName(editorPane.getFileName());
-				toggleWhiteSpaceLabeling.setSelected(((RSyntaxTextArea) editorPane)
-					.isWhitespaceVisible());
-			}
-		});
+		
+		editorPane.setLanguageByFileName(editorPane.getFileName());
+		toggleWhiteSpaceLabeling.setSelected(editorPane.isWhitespaceVisible());
 	}
 
 	public EditorPane getEditorPane(final int index) {
@@ -1929,15 +1923,6 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	synchronized void setTitle() {
-		/* 
-		 * This method might still get called after all tabs have been closed because
-		 * the ScriptEditor is being shutdown and we saved our changes via the dialog.
-		 * Therefore, we need to check if there actually is a tab to set the title for.
-		 */
-		if (tabbed.getTabCount() == 0) {
-			return;
-		}
-		
 		final Tab tab = getTab();
 
 		final boolean fileChanged = tab.editorPane.fileChanged();

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -611,7 +611,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			@Override
 			public void windowGainedFocus(WindowEvent e) {
 				final EditorPane editorPane = getEditorPane();
-				if (editorPane != null) editorPane.checkForOutsideChanges();
+				editorPane.checkForOutsideChanges();
 			}
 		});
 
@@ -653,7 +653,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		open(null);
 
 		final EditorPane editorPane = getEditorPane();
-		if (editorPane != null) editorPane.requestFocus();
+		editorPane.requestFocus();
 	}
 
 	private synchronized static void initializeTokenMakers(
@@ -755,9 +755,42 @@ public class TextEditor extends JFrame implements ActionListener,
 		return getEditorPane();
 	}
 
+	/**
+	 * Get the currently selected tab.
+	 * 
+	 * @return The currently selected tab. Never null.
+	 */
+	public Tab getTab() {
+		int index = tabbed.getSelectedIndex();
+		if (index < 0) {
+			// should not happen, but safety first.
+			if (tabbed.getTabCount() == 0) {
+				// should not happen either, but, again, safety first.
+				createNewDocument();
+			}
+
+			tabbed.setSelectedIndex(0);
+		}
+		return (Tab) tabbed.getComponentAt(index);
+	}
+
+	/**
+	 * Get tab at provided index.
+	 * 
+	 * @param index the index of the tab.
+	 * @return the {@link Tab} at given index or <code>null</code>.
+	 */
+	public Tab getTab(int index) {
+		return (Tab) tabbed.getComponentAt(index);
+	}
+
+	/**
+	 * Return the {@link EditorPane} of the currently selected {@link Tab}.
+	 * 
+	 * @return the current {@link EditorPane}. Never <code>null</code>.
+	 */
 	public EditorPane getEditorPane() {
-		Tab tab = getTab();
-		return tab == null ? null : tab.editorPane;
+		return getTab().editorPane;
 	}
 
 	public ScriptLanguage getCurrentLanguage() {
@@ -1027,7 +1060,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		else if (source == open) {
 			final EditorPane editorPane = getEditorPane();
 			final File defaultDir =
-				editorPane != null && editorPane.file != null ? editorPane.file
+				editorPane.file != null ? editorPane.file
 					.getParentFile() : AppUtils.getBaseDirectory("imagej.dir",
 					TextEditor.class, null);
 			final File file = openWithDialog(defaultDir);
@@ -1104,7 +1137,9 @@ public class TextEditor extends JFrame implements ActionListener,
 			.convertTabsToSpaces();
 		else if (source == replaceSpacesWithTabs) getTextArea()
 			.convertSpacesToTabs();
-		else if (source == clearScreen) getTab().getScreen().setText("");
+		else if (source == clearScreen) {
+			getTab().getScreen().setText("");
+		}
 		else if (source == zapGremlins) zapGremlins();
 		else if (source == savePreferences) savePreferences();
 		else if (source == openHelp) openHelp(null);
@@ -1286,16 +1321,6 @@ public class TextEditor extends JFrame implements ActionListener,
 				break;
 		}
 		return false;
-	}
-
-	public Tab getTab() {
-		int index = tabbed.getSelectedIndex();
-		if (index < 0) return null;
-		return (Tab) tabbed.getComponentAt(index);
-	}
-
-	public Tab getTab(int index) {
-		return (Tab) tabbed.getComponentAt(index);
 	}
 
 	public class Tab extends JSplitPane {
@@ -1632,7 +1657,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 
 		try {
-			Tab tab = getTab();
+			Tab tab = (tabbed.getTabCount() == 0) ? null : getTab();
 			boolean wasNew = tab != null && tab.editorPane.isNew();
 			if (!wasNew) {
 				tab = new Tab();
@@ -1872,7 +1897,6 @@ public class TextEditor extends JFrame implements ActionListener,
 		nextError.setVisible(!isMacro && isRunnable);
 		previousError.setVisible(!isMacro && isRunnable);
 
-		if (getEditorPane() == null) return;
 		boolean isInGit = getEditorPane().getGitDirectory() != null;
 		gitMenu.setVisible(isInGit);
 
@@ -1934,7 +1958,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	synchronized void setTitle() {
 		final Tab tab = getTab();
-		if (null == tab || null == tab.editorPane) return;
+
 		final boolean fileChanged = tab.editorPane.fileChanged();
 		final String fileName = tab.editorPane.getFileName();
 		final String title =

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -964,7 +964,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		final EditorPane editorPane = getEditorPane();
 		editorPane.setText(text);
 		setEditorPaneFileName(title);
-		
+
 		editorPane.setLanguageByFileName(title);
 		updateLanguageMenu(editorPane.getCurrentLanguage());
 	}
@@ -1279,7 +1279,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	public boolean reload(final String message) {
 		final EditorPane editorPane = getEditorPane();
-		
+
 		final File file = editorPane.getFile();
 		if (file == null || !file.exists()) return true;
 
@@ -1394,7 +1394,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			if (file != null) openRecent.add(file.getAbsolutePath());
 
 			updateLanguageMenu(tab.editorPane.getCurrentLanguage());
-			
+
 			return tab;
 		}
 		catch (final FileNotFoundException e) {
@@ -1445,7 +1445,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		if (!write(file)) {
 			return false;
 		}
-		
+
 		setTitle();
 
 		return true;
@@ -1574,7 +1574,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	void setLanguage(final ScriptLanguage language, final boolean addHeader) {
 		getEditorPane().setLanguage(language, addHeader);
-		
+
 		setTitle();
 		updateLanguageMenu(language);
 		updateTabAndFontSize(true);
@@ -1679,7 +1679,7 @@ public class TextEditor extends JFrame implements ActionListener,
 	public void setEditorPaneFileName(final File file) {
 		final EditorPane editorPane = getEditorPane();
 		editorPane.setFileName(file);
-		
+
 		// update language menu
 		updateLanguageMenu(editorPane.getCurrentLanguage());
 	}

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -1685,6 +1685,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		// update language menu
 		updateLanguageMenu(editorPane.getCurrentLanguage());
+		updateGitDirectory();
 	}
 
 	void setTitle() {
@@ -2214,6 +2215,17 @@ public class TextEditor extends JFrame implements ActionListener,
 			if (file != null && file.getName().equals(baseName)) return file;
 		}
 		return null;
+	}
+
+	/**
+	 * Update the git directory to the git directory of the current file.
+	 * 
+	 * @see #getGitDirectory()
+	 */
+	protected void updateGitDirectory() {
+		EditorPane editorPane = getEditorPane();
+		editorPane.setGitDirectory(new FileFunctions(this)
+			.getGitDirectory(editorPane.getFile()));
 	}
 
 	public void addImport(String className) {

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -144,11 +144,11 @@ import org.scijava.widget.FileWidget;
  * A versatile script editor for ImageJ.
  * <p>
  * Based on the powerful SciJava scripting framework and the <a
- * href="http://fifesoft.com/rsyntaxtextarea/">RSyntaxTextArea</a> library,
- * this text editor offers users to script their way through image processing.
- * Thanks to the <a href="https://github.com/scijava/scripting-java">Java
- * backend for SciJava scripting</a>, it is even possible to develop Java
- * plugins in the editor.
+ * href="http://fifesoft.com/rsyntaxtextarea/">RSyntaxTextArea</a> library, this
+ * text editor offers users to script their way through image processing. Thanks
+ * to the <a href="https://github.com/scijava/scripting-java">Java backend for
+ * SciJava scripting</a>, it is even possible to develop Java plugins in the
+ * editor.
  * </p>
  * 
  * @author Johannes Schindelin
@@ -156,7 +156,8 @@ import org.scijava.widget.FileWidget;
  */
 @SuppressWarnings("serial")
 public class TextEditor extends JFrame implements ActionListener,
-	       ChangeListener, CloseConfirmable {
+	ChangeListener, CloseConfirmable
+{
 
 	private static final Set<String> TEMPLATE_PATHS = new HashSet<String>();
 	public static final String AUTO_IMPORT_PREFS = "script.editor.AutoImport";
@@ -181,23 +182,20 @@ public class TextEditor extends JFrame implements ActionListener,
 	private static AbstractTokenMakerFactory tokenMakerFactory = null;
 
 	protected JTabbedPane tabbed;
-	protected JMenuItem newFile, open, save, saveas, compileAndRun, compile, close,
-		  undo, redo, cut, copy, paste, find, replace, selectAll,
-		  kill, gotoLine,
-		  makeJar, makeJarWithSource, removeUnusedImports,
-		  sortImports, removeTrailingWhitespace, findNext, findPrevious,
-		  openHelp, addImport, clearScreen, nextError, previousError,
-		  openHelpWithoutFrames, nextTab, previousTab,
-		  runSelection, extractSourceJar, toggleBookmark,
-		  listBookmarks, openSourceForClass,
-		  openSourceForMenuItem,
-		  openMacroFunctions, decreaseFontSize, increaseFontSize,
-		  chooseFontSize, chooseTabSize, gitGrep, openInGitweb,
-		  replaceTabsWithSpaces, replaceSpacesWithTabs, toggleWhiteSpaceLabeling,
-		  zapGremlins, savePreferences;
+	protected JMenuItem newFile, open, save, saveas, compileAndRun, compile,
+			close, undo, redo, cut, copy, paste, find, replace, selectAll, kill,
+			gotoLine, makeJar, makeJarWithSource, removeUnusedImports, sortImports,
+			removeTrailingWhitespace, findNext, findPrevious, openHelp, addImport,
+			clearScreen, nextError, previousError, openHelpWithoutFrames, nextTab,
+			previousTab, runSelection, extractSourceJar, toggleBookmark,
+			listBookmarks, openSourceForClass, openSourceForMenuItem,
+			openMacroFunctions, decreaseFontSize, increaseFontSize, chooseFontSize,
+			chooseTabSize, gitGrep, openInGitweb, replaceTabsWithSpaces,
+			replaceSpacesWithTabs, toggleWhiteSpaceLabeling, zapGremlins,
+			savePreferences;
 	protected RecentFilesMenuItem openRecent;
-	protected JMenu gitMenu, tabsMenu, fontSizeMenu, tabSizeMenu, toolsMenu, runMenu,
-		  whiteSpaceMenu;
+	protected JMenu gitMenu, tabsMenu, fontSizeMenu, tabSizeMenu, toolsMenu,
+			runMenu, whiteSpaceMenu;
 	protected int tabsMenuTabsStart;
 	protected Set<JMenuItem> tabsMenuItems;
 	protected FindAndReplaceDialog findDialog;
@@ -252,9 +250,9 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		JMenu file = new JMenu("File");
 		file.setMnemonic(KeyEvent.VK_F);
-		newFile = addToMenu(file, "New",  KeyEvent.VK_N, ctrl);
+		newFile = addToMenu(file, "New", KeyEvent.VK_N, ctrl);
 		newFile.setMnemonic(KeyEvent.VK_N);
-		open = addToMenu(file, "Open...",  KeyEvent.VK_O, ctrl);
+		open = addToMenu(file, "Open...", KeyEvent.VK_O, ctrl);
 		open.setMnemonic(KeyEvent.VK_O);
 		openRecent = new RecentFilesMenuItem(prefService, this);
 		openRecent.setMnemonic(KeyEvent.VK_R);
@@ -299,18 +297,21 @@ public class TextEditor extends JFrame implements ActionListener,
 		edit.addSeparator();
 
 		// Font adjustments
-		decreaseFontSize = addToMenu(edit, "Decrease font size", KeyEvent.VK_MINUS, ctrl);
+		decreaseFontSize =
+			addToMenu(edit, "Decrease font size", KeyEvent.VK_MINUS, ctrl);
 		decreaseFontSize.setMnemonic(KeyEvent.VK_D);
-		increaseFontSize = addToMenu(edit, "Increase font size", KeyEvent.VK_PLUS, ctrl);
+		increaseFontSize =
+			addToMenu(edit, "Increase font size", KeyEvent.VK_PLUS, ctrl);
 		increaseFontSize.setMnemonic(KeyEvent.VK_C);
 
 		fontSizeMenu = new JMenu("Font sizes");
 		fontSizeMenu.setMnemonic(KeyEvent.VK_Z);
 		boolean[] fontSizeShortcutUsed = new boolean[10];
 		ButtonGroup buttonGroup = new ButtonGroup();
-		for (final int size : new int[] { 8, 10, 12, 16, 20, 28, 42 } ) {
+		for (final int size : new int[] { 8, 10, 12, 16, 20, 28, 42 }) {
 			JRadioButtonMenuItem item = new JRadioButtonMenuItem("" + size + " pt");
 			item.addActionListener(new ActionListener() {
+
 				@Override
 				public void actionPerformed(ActionEvent event) {
 					getEditorPane().setFontSize(size);
@@ -342,6 +343,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		for (final int size : new int[] { 2, 4, 8 }) {
 			JRadioButtonMenuItem item = new JRadioButtonMenuItem("" + size);
 			item.addActionListener(new ActionListener() {
+
 				@Override
 				public void actionPerformed(ActionEvent event) {
 					getEditorPane().setTabSize(size);
@@ -361,6 +363,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		wrapLines = new JCheckBoxMenuItem("Wrap lines");
 		wrapLines.addChangeListener(new ChangeListener() {
+
 			@Override
 			public void stateChanged(ChangeEvent e) {
 				getEditorPane().setLineWrap(wrapLines.getState());
@@ -371,6 +374,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		// Add Tab inserts as spaces
 		tabsEmulated = new JCheckBoxMenuItem("Tab key inserts spaces");
 		tabsEmulated.addChangeListener(new ChangeListener() {
+
 			@Override
 			public void stateChanged(ChangeEvent e) {
 				getEditorPane().setTabsEmulated(tabsEmulated.getState());
@@ -395,7 +399,8 @@ public class TextEditor extends JFrame implements ActionListener,
 		sortImports = addToMenu(edit, "Sort imports", 0, 0);
 		sortImports.setMnemonic(KeyEvent.VK_S);
 		respectAutoImports = prefService.getBoolean(AUTO_IMPORT_PREFS, false);
-		autoImport = new JCheckBoxMenuItem("Auto-import (deprecated)", respectAutoImports);
+		autoImport =
+			new JCheckBoxMenuItem("Auto-import (deprecated)", respectAutoImports);
 		autoImport.addItemListener(new ItemListener() {
 
 			@Override
@@ -409,25 +414,31 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		whiteSpaceMenu = new JMenu("Whitespace");
 		whiteSpaceMenu.setMnemonic(KeyEvent.VK_W);
-		removeTrailingWhitespace = addToMenu(whiteSpaceMenu, "Remove trailing whitespace", 0, 0);
+		removeTrailingWhitespace =
+			addToMenu(whiteSpaceMenu, "Remove trailing whitespace", 0, 0);
 		removeTrailingWhitespace.setMnemonic(KeyEvent.VK_W);
-		replaceTabsWithSpaces = addToMenu(whiteSpaceMenu, "Replace tabs with spaces", 0, 0);
+		replaceTabsWithSpaces =
+			addToMenu(whiteSpaceMenu, "Replace tabs with spaces", 0, 0);
 		replaceTabsWithSpaces.setMnemonic(KeyEvent.VK_S);
-		replaceSpacesWithTabs = addToMenu(whiteSpaceMenu, "Replace spaces with tabs", 0, 0);
+		replaceSpacesWithTabs =
+			addToMenu(whiteSpaceMenu, "Replace spaces with tabs", 0, 0);
 		replaceSpacesWithTabs.setMnemonic(KeyEvent.VK_T);
 		toggleWhiteSpaceLabeling = new JRadioButtonMenuItem("Label whitespace");
 		toggleWhiteSpaceLabeling.setMnemonic(KeyEvent.VK_L);
 		toggleWhiteSpaceLabeling.addActionListener(new ActionListener() {
+
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				getTextArea().setWhitespaceVisible(toggleWhiteSpaceLabeling.isSelected());
+				getTextArea().setWhitespaceVisible(
+					toggleWhiteSpaceLabeling.isSelected());
 			}
 		});
 		whiteSpaceMenu.add(toggleWhiteSpaceLabeling);
 
 		edit.add(whiteSpaceMenu);
 
-		languageMenuItems = new LinkedHashMap<ScriptLanguage, JRadioButtonMenuItem>();
+		languageMenuItems =
+			new LinkedHashMap<ScriptLanguage, JRadioButtonMenuItem>();
 		Set<Integer> usedShortcuts = new HashSet<Integer>();
 		JMenu languages = new JMenu("Language");
 		languages.setMnemonic(KeyEvent.VK_L);
@@ -437,6 +448,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		final ArrayList<ScriptLanguage> list =
 			new ArrayList<ScriptLanguage>(scriptService.getLanguages());
 		Collections.sort(list, new Comparator<ScriptLanguage>() {
+
 			@Override
 			public int compare(final ScriptLanguage l1, final ScriptLanguage l2) {
 				final String name1 = l1.getLanguageName();
@@ -446,7 +458,8 @@ public class TextEditor extends JFrame implements ActionListener,
 		});
 		list.add(null);
 
-		Map<String, ScriptLanguage> languageMap = new HashMap<String, ScriptLanguage>();
+		Map<String, ScriptLanguage> languageMap =
+			new HashMap<String, ScriptLanguage>();
 		for (final ScriptLanguage language : list) {
 			String name = language == null ? "None" : language.getLanguageName();
 			languageMap.put(name, language);
@@ -454,7 +467,8 @@ public class TextEditor extends JFrame implements ActionListener,
 			JRadioButtonMenuItem item = new JRadioButtonMenuItem(name);
 			if (language == null) {
 				noneLanguageItem = item;
-			} else {
+			}
+			else {
 				languageMenuItems.put(language, item);
 			}
 
@@ -468,6 +482,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			}
 			if (shortcut > 0) item.setMnemonic(shortcut);
 			item.addActionListener(new ActionListener() {
+
 				@Override
 				public void actionPerformed(ActionEvent e) {
 					setLanguage(language, true);
@@ -488,16 +503,14 @@ public class TextEditor extends JFrame implements ActionListener,
 		runMenu = new JMenu("Run");
 		runMenu.setMnemonic(KeyEvent.VK_R);
 
-		compileAndRun = addToMenu(runMenu, "Compile and Run",
-				KeyEvent.VK_R, ctrl);
+		compileAndRun = addToMenu(runMenu, "Compile and Run", KeyEvent.VK_R, ctrl);
 		compileAndRun.setMnemonic(KeyEvent.VK_R);
 
-		runSelection = addToMenu(runMenu, "Run selected code",
-				KeyEvent.VK_R, ctrl | shift);
+		runSelection =
+			addToMenu(runMenu, "Run selected code", KeyEvent.VK_R, ctrl | shift);
 		runSelection.setMnemonic(KeyEvent.VK_S);
 
-		compile = addToMenu(runMenu, "Compile",
-				KeyEvent.VK_C, ctrl | shift);
+		compile = addToMenu(runMenu, "Compile", KeyEvent.VK_C, ctrl | shift);
 		compile.setMnemonic(KeyEvent.VK_C);
 		autoSave = new JCheckBoxMenuItem("Auto-save before compiling");
 		runMenu.add(autoSave);
@@ -518,23 +531,22 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		toolsMenu = new JMenu("Tools");
 		toolsMenu.setMnemonic(KeyEvent.VK_O);
-		openHelpWithoutFrames = addToMenu(toolsMenu,
-			"Open Help for Class...", 0, 0);
+		openHelpWithoutFrames =
+			addToMenu(toolsMenu, "Open Help for Class...", 0, 0);
 		openHelpWithoutFrames.setMnemonic(KeyEvent.VK_O);
-		openHelp = addToMenu(toolsMenu,
-			"Open Help for Class (with frames)...", 0, 0);
+		openHelp =
+			addToMenu(toolsMenu, "Open Help for Class (with frames)...", 0, 0);
 		openHelp.setMnemonic(KeyEvent.VK_P);
-		openMacroFunctions = addToMenu(toolsMenu,
-			"Open Help on Macro Functions...", 0, 0);
+		openMacroFunctions =
+			addToMenu(toolsMenu, "Open Help on Macro Functions...", 0, 0);
 		openMacroFunctions.setMnemonic(KeyEvent.VK_H);
-		extractSourceJar = addToMenu(toolsMenu,
-			"Extract source .jar...", 0, 0);
+		extractSourceJar = addToMenu(toolsMenu, "Extract source .jar...", 0, 0);
 		extractSourceJar.setMnemonic(KeyEvent.VK_E);
-		openSourceForClass = addToMenu(toolsMenu,
-			"Open .java file for class...", 0, 0);
+		openSourceForClass =
+			addToMenu(toolsMenu, "Open .java file for class...", 0, 0);
 		openSourceForClass.setMnemonic(KeyEvent.VK_J);
-		openSourceForMenuItem = addToMenu(toolsMenu,
-			"Open .java file for menu item...", 0, 0);
+		openSourceForMenuItem =
+			addToMenu(toolsMenu, "Open .java file for menu item...", 0, 0);
 		openSourceForMenuItem.setMnemonic(KeyEvent.VK_M);
 		mbar.add(toolsMenu);
 
@@ -548,21 +560,18 @@ public class TextEditor extends JFrame implements ActionListener,
 			"Commit...", 0, 0);
 		commit.setMnemonic(KeyEvent.VK_C);
 		*/
-		gitGrep = addToMenu(gitMenu,
-			"Grep...", 0, 0);
+		gitGrep = addToMenu(gitMenu, "Grep...", 0, 0);
 		gitGrep.setMnemonic(KeyEvent.VK_G);
-		openInGitweb = addToMenu(gitMenu,
-			"Open in gitweb", 0, 0);
+		openInGitweb = addToMenu(gitMenu, "Open in gitweb", 0, 0);
 		openInGitweb.setMnemonic(KeyEvent.VK_W);
 		mbar.add(gitMenu);
 
 		tabsMenu = new JMenu("Tabs");
 		tabsMenu.setMnemonic(KeyEvent.VK_A);
-		nextTab = addToMenu(tabsMenu, "Next Tab",
-				KeyEvent.VK_PAGE_DOWN, ctrl);
+		nextTab = addToMenu(tabsMenu, "Next Tab", KeyEvent.VK_PAGE_DOWN, ctrl);
 		nextTab.setMnemonic(KeyEvent.VK_N);
-		previousTab = addToMenu(tabsMenu, "Previous Tab",
-				KeyEvent.VK_PAGE_UP, ctrl);
+		previousTab =
+			addToMenu(tabsMenu, "Previous Tab", KeyEvent.VK_PAGE_UP, ctrl);
 		previousTab.setMnemonic(KeyEvent.VK_P);
 		tabsMenu.addSeparator();
 		tabsMenuTabsStart = tabsMenu.getItemCount();
@@ -575,7 +584,8 @@ public class TextEditor extends JFrame implements ActionListener,
 		open(null); // make sure the editor pane is added
 
 		tabbed.setBorder(BorderFactory.createEmptyBorder(4, 4, 4, 4));
-		getContentPane().setLayout(new BoxLayout(getContentPane(), BoxLayout.Y_AXIS));
+		getContentPane().setLayout(
+			new BoxLayout(getContentPane(), BoxLayout.Y_AXIS));
 		getContentPane().add(tabbed);
 
 		// for Eclipse and MS Visual Studio lovers
@@ -588,6 +598,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		// make sure that the window is not closed by accident
 		addWindowListener(new WindowAdapter() {
+
 			@Override
 			public void windowClosing(WindowEvent e) {
 				if (!confirmClose()) return;
@@ -596,11 +607,11 @@ public class TextEditor extends JFrame implements ActionListener,
 		});
 
 		addWindowFocusListener(new WindowAdapter() {
+
 			@Override
 			public void windowGainedFocus(WindowEvent e) {
 				final EditorPane editorPane = getEditorPane();
-				if (editorPane != null)
-					editorPane.checkForOutsideChanges();
+				if (editorPane != null) editorPane.checkForOutsideChanges();
 			}
 		});
 
@@ -614,19 +625,23 @@ public class TextEditor extends JFrame implements ActionListener,
 		try {
 			if (SwingUtilities.isEventDispatchThread()) {
 				pack();
-			} else {
+			}
+			else {
 				SwingUtilities.invokeAndWait(new Runnable() {
+
 					@Override
 					public void run() {
 						pack();
 					}
 				});
 			}
-		} catch (Exception ie) {}
+		}
+		catch (Exception ie) {}
 		findDialog = new FindAndReplaceDialog(this);
 
 		// Save the size of the window in the preferences
 		addComponentListener(new ComponentAdapter() {
+
 			@Override
 			public void componentResized(ComponentEvent e) {
 				saveWindowSizeToPrefs();
@@ -638,18 +653,24 @@ public class TextEditor extends JFrame implements ActionListener,
 		open(null);
 
 		final EditorPane editorPane = getEditorPane();
-		if (editorPane != null)
-			editorPane.requestFocus();
+		if (editorPane != null) editorPane.requestFocus();
 	}
 
-	private synchronized static void initializeTokenMakers(final PluginService pluginService, final LogService log) {
+	private synchronized static void initializeTokenMakers(
+		final PluginService pluginService, final LogService log)
+	{
 		if (tokenMakerFactory != null) return;
-		tokenMakerFactory = (AbstractTokenMakerFactory)TokenMakerFactory.getDefaultInstance();
-		for (final PluginInfo<SyntaxHighlighter> info : pluginService.getPluginsOfType(SyntaxHighlighter.class)) try {
-			tokenMakerFactory.putMapping("text/" + info.getLabel(), info.getClassName());
-		} catch (Throwable t) {
-			log.warn("Could not register " + info.getLabel(), t);
-		}
+		tokenMakerFactory =
+			(AbstractTokenMakerFactory) TokenMakerFactory.getDefaultInstance();
+		for (final PluginInfo<SyntaxHighlighter> info : pluginService
+			.getPluginsOfType(SyntaxHighlighter.class))
+			try {
+				tokenMakerFactory.putMapping("text/" + info.getLabel(), info
+					.getClassName());
+			}
+			catch (Throwable t) {
+				log.warn("Could not register " + info.getLabel(), t);
+			}
 	}
 
 	/**
@@ -663,13 +684,24 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	@Plugin(type = SyntaxHighlighter.class, label = "ecmascript")
-	public static class ECMAScriptHighlighter extends JavaScriptTokenMaker implements SyntaxHighlighter {} 
+	public static class ECMAScriptHighlighter extends JavaScriptTokenMaker
+		implements SyntaxHighlighter
+	{}
+
 	@Plugin(type = SyntaxHighlighter.class, label = "matlab")
-	public static class MatlabHighlighter extends MatlabTokenMaker implements SyntaxHighlighter {} 
+	public static class MatlabHighlighter extends MatlabTokenMaker implements
+		SyntaxHighlighter
+	{}
+
 	@Plugin(type = SyntaxHighlighter.class, label = "ij1-macro")
-	public static class IJ1MacroHighlighter extends ImageJMacroTokenMaker implements SyntaxHighlighter {} 
+	public static class IJ1MacroHighlighter extends ImageJMacroTokenMaker
+		implements SyntaxHighlighter
+	{}
+
 	@Plugin(type = SyntaxHighlighter.class, label = "beanshell")
-	public static class BeanshellHighlighter extends JavaTokenMaker implements SyntaxHighlighter {} 
+	public static class BeanshellHighlighter extends JavaTokenMaker implements
+		SyntaxHighlighter
+	{}
 
 	@EventHandler
 	private void onEvent(final ContextDisposingEvent e) {
@@ -683,23 +715,21 @@ public class TextEditor extends JFrame implements ActionListener,
 		Dimension dim = getSize();
 
 		// If a dimension is 0 then use the default dimension size
-		if( 0 == dim.width) {
+		if (0 == dim.width) {
 			dim.width = DEFAULT_WINDOW_WIDTH;
 		}
-		if( 0 == dim.height ) {
+		if (0 == dim.height) {
 			dim.height = DEFAULT_WINDOW_HEIGHT;
 		}
 
-		setPreferredSize(
-			new Dimension(
-				prefService.getInt(WINDOW_WIDTH, dim.width),
-				prefService.getInt(WINDOW_HEIGHT, dim.height) ) );
+		setPreferredSize(new Dimension(prefService.getInt(WINDOW_WIDTH, dim.width),
+			prefService.getInt(WINDOW_HEIGHT, dim.height)));
 	}
 
 	/**
 	 * Retrieves and saves the preferences to the persistent store
 	 */
-	public void savePreferences(){
+	public void savePreferences() {
 		EditorPane pane = getEditorPane();
 		prefService.put(TAB_SIZE_PREFS, pane.getTabSize());
 		prefService.put(FONT_SIZE_PREFS, pane.getFontSize());
@@ -709,17 +739,15 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	/**
 	 * Saves the window size to preferences.
-	 *
 	 * <p>
-	 * Separated from savePreferences because we always want to save the
-	 * window size when it's resized, however, we don't want to
-	 * automatically save the font, tab size, etc. without the user
-	 * pressing "Save Preferences"
+	 * Separated from savePreferences because we always want to save the window
+	 * size when it's resized, however, we don't want to automatically save the
+	 * font, tab size, etc. without the user pressing "Save Preferences"
 	 * </p>
 	 */
-	public void saveWindowSizeToPrefs(){
-		Dimension dim  = getSize();
-		prefService.put(WINDOW_HEIGHT,dim.height);
+	public void saveWindowSizeToPrefs() {
+		Dimension dim = getSize();
+		prefService.put(WINDOW_HEIGHT, dim.height);
 		prefService.put(WINDOW_WIDTH, dim.width);
 	}
 
@@ -736,18 +764,18 @@ public class TextEditor extends JFrame implements ActionListener,
 		return getEditorPane().currentLanguage;
 	}
 
-	public JMenuItem addToMenu(JMenu menu, String menuEntry,
-			int key, int modifiers) {
+	public JMenuItem addToMenu(JMenu menu, String menuEntry, int key,
+		int modifiers)
+	{
 		JMenuItem item = new JMenuItem(menuEntry);
 		menu.add(item);
-		if (key != 0)
-			item.setAccelerator(KeyStroke.getKeyStroke(key,
-						modifiers));
+		if (key != 0) item.setAccelerator(KeyStroke.getKeyStroke(key, modifiers));
 		item.addActionListener(this);
 		return item;
 	}
 
 	protected static class AcceleratorTriplet {
+
 		JMenuItem component;
 		int key, modifiers;
 	}
@@ -755,12 +783,14 @@ public class TextEditor extends JFrame implements ActionListener,
 	protected List<AcceleratorTriplet> defaultAccelerators =
 		new ArrayList<AcceleratorTriplet>();
 
-	public void addAccelerator(final JMenuItem component,
-			int key, int modifiers) {
+	public void addAccelerator(final JMenuItem component, int key, int modifiers)
+	{
 		addAccelerator(component, key, modifiers, false);
 	}
 
-	public void addAccelerator(final JMenuItem component, int key, int modifiers, boolean record) {
+	public void addAccelerator(final JMenuItem component, int key, int modifiers,
+		boolean record)
+	{
 		if (record) {
 			AcceleratorTriplet triplet = new AcceleratorTriplet();
 			triplet.component = component;
@@ -770,21 +800,20 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 
 		RSyntaxTextArea textArea = getTextArea();
-		if (textArea != null)
-			addAccelerator(textArea, component, key, modifiers);
+		if (textArea != null) addAccelerator(textArea, component, key, modifiers);
 	}
 
-	public void addAccelerator(RSyntaxTextArea textArea, final JMenuItem component, int key, int modifiers) {
-		textArea.getInputMap().put(KeyStroke.getKeyStroke(key,
-					modifiers), component);
-		textArea.getActionMap().put(component,
-				new AbstractAction() {
+	public void addAccelerator(RSyntaxTextArea textArea,
+		final JMenuItem component, int key, int modifiers)
+	{
+		textArea.getInputMap().put(KeyStroke.getKeyStroke(key, modifiers),
+			component);
+		textArea.getActionMap().put(component, new AbstractAction() {
+
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				if (!component.isEnabled())
-					return;
-				ActionEvent event = new ActionEvent(component,
-					0, "Accelerator");
+				if (!component.isEnabled()) return;
+				ActionEvent event = new ActionEvent(component, 0, "Accelerator");
 				TextEditor.this.actionPerformed(event);
 			}
 		});
@@ -792,24 +821,24 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	public void addDefaultAccelerators(RSyntaxTextArea textArea) {
 		for (AcceleratorTriplet triplet : defaultAccelerators)
-			addAccelerator(textArea, triplet.component, triplet.key, triplet.modifiers);
+			addAccelerator(textArea, triplet.component, triplet.key,
+				triplet.modifiers);
 	}
 
-	protected JMenu getMenu(JMenu root, String menuItemPath, boolean createIfNecessary) {
+	protected JMenu getMenu(JMenu root, String menuItemPath,
+		boolean createIfNecessary)
+	{
 		int gt = menuItemPath.indexOf('>');
-		if (gt < 0)
-			return root;
+		if (gt < 0) return root;
 
 		String menuLabel = menuItemPath.substring(0, gt);
 		String rest = menuItemPath.substring(gt + 1);
 		for (int i = 0; i < root.getItemCount(); i++) {
 			JMenuItem item = root.getItem(i);
-			if ((item instanceof JMenu) &&
-					menuLabel.equals(item.getText()))
-				return getMenu((JMenu)item, rest, createIfNecessary);
+			if ((item instanceof JMenu) && menuLabel.equals(item.getText())) return getMenu(
+				(JMenu) item, rest, createIfNecessary);
 		}
-		if (!createIfNecessary)
-			return null;
+		if (!createIfNecessary) return null;
 		JMenu subMenu = new JMenu(menuLabel);
 		root.add(subMenu);
 		return getMenu(subMenu, rest, createIfNecessary);
@@ -827,12 +856,12 @@ public class TextEditor extends JFrame implements ActionListener,
 	 * for languages unknown to the script service will be discarded quietly.
 	 * </p>
 	 * 
-	 * @param templatesMenu
-	 *            the top-level menu to populate
-	 * @param languageMap
-	 *            the known languages
+	 * @param templatesMenu the top-level menu to populate
+	 * @param languageMap the known languages
 	 */
-	protected void addTemplates(JMenu templatesMenu, Map<String, ScriptLanguage> languageMap) {
+	protected void addTemplates(JMenu templatesMenu,
+		Map<String, ScriptLanguage> languageMap)
+	{
 		for (final String templatePath : TEMPLATE_PATHS) {
 			for (final Map.Entry<String, URL> entry : new TreeMap<String, URL>(
 				FileFunctions.findResources(null, templatePath)).entrySet())
@@ -877,7 +906,8 @@ public class TextEditor extends JFrame implements ActionListener,
 	public void loadTemplate(final String url) {
 		try {
 			loadTemplate(new URL(url));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			log.error(e);
 			error("The template '" + url + "' was not found.");
 		}
@@ -906,7 +936,8 @@ public class TextEditor extends JFrame implements ActionListener,
 			}
 			final String path = url.getPath();
 			setFileName(path.substring(path.lastIndexOf('/') + 1));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			e.printStackTrace();
 			error("The template '" + url + "' was not found.");
 		}
@@ -926,7 +957,8 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	/**
-	 * Open a new editor to edit the given file, with a templateFile if the file does not exist yet
+	 * Open a new editor to edit the given file, with a templateFile if the file
+	 * does not exist yet
 	 */
 	public void createNewFromTemplate(File file, File templateFile) {
 		open(file.exists() ? file : templateFile);
@@ -934,7 +966,8 @@ public class TextEditor extends JFrame implements ActionListener,
 			final EditorPane editorPane = getEditorPane();
 			try {
 				editorPane.open(file);
-			} catch (IOException e) {
+			}
+			catch (IOException e) {
 				handleException(e);
 			}
 			editorPane.setLanguageByFileName(file.getName());
@@ -951,21 +984,18 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public boolean handleUnsavedChanges(boolean beforeCompiling) {
-		if (!fileChanged())
-			return true;
+		if (!fileChanged()) return true;
 
 		if (beforeCompiling && autoSave.getState()) {
 			save();
 			return true;
 		}
 
-		switch (JOptionPane.showConfirmDialog(this,
-				"Do you want to save changes?")) {
-		case JOptionPane.NO_OPTION:
-			return true;
-		case JOptionPane.YES_OPTION:
-			if (save())
+		switch (JOptionPane.showConfirmDialog(this, "Do you want to save changes?")) {
+			case JOptionPane.NO_OPTION:
 				return true;
+			case JOptionPane.YES_OPTION:
+				if (save()) return true;
 		}
 
 		return false;
@@ -982,6 +1012,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 
 		SwingUtilities.invokeLater(new Thread() {
+
 			@Override
 			public void run() {
 				grabFocus(laterCount - 1);
@@ -992,89 +1023,66 @@ public class TextEditor extends JFrame implements ActionListener,
 	@Override
 	public void actionPerformed(ActionEvent ae) {
 		final Object source = ae.getSource();
-		if (source == newFile)
-			createNewDocument();
+		if (source == newFile) createNewDocument();
 		else if (source == open) {
 			final EditorPane editorPane = getEditorPane();
-			final File defaultDir = editorPane != null && editorPane.file != null ?
-				editorPane.file.getParentFile() : AppUtils.getBaseDirectory("imagej.dir", TextEditor.class, null);
+			final File defaultDir =
+				editorPane != null && editorPane.file != null ? editorPane.file
+					.getParentFile() : AppUtils.getBaseDirectory("imagej.dir",
+					TextEditor.class, null);
 			final File file = openWithDialog(defaultDir);
-			if (file != null)
-				new Thread() {
-					@Override
-					public void run() {
-						open(file);
-					}
-				}.start();
+			if (file != null) new Thread() {
+
+				@Override
+				public void run() {
+					open(file);
+				}
+			}.start();
 			return;
 		}
-		else if (source == save)
-			save();
-		else if (source == saveas)
-			saveAs();
-		else if (source == makeJar)
-			makeJar(false);
-		else if (source == makeJarWithSource)
-			makeJar(true);
-		else if (source == compileAndRun)
-			runText();
-		else if (source == compile)
-			compile();
-		else if (source == runSelection)
-			runText(true);
-		else if (source == nextError)
-			new Thread() {
-				@Override
-				public void run() {
-					nextError(true);
-				}
-			}.start();
-		else if (source == previousError)
-			new Thread() {
-				@Override
-				public void run() {
-					nextError(false);
-				}
-			}.start();
-		else if (source == kill)
-			chooseTaskToKill();
-		else if (source == close)
-			if (tabbed.getTabCount() < 2)
-				processWindowEvent(new WindowEvent(this,
-						WindowEvent.WINDOW_CLOSING));
-			else {
-				if (!handleUnsavedChanges())
-					return;
-				int index = tabbed.getSelectedIndex();
-				removeTab(index);
-				if (index > 0)
-					index--;
-				switchTo(index);
+		else if (source == save) save();
+		else if (source == saveas) saveAs();
+		else if (source == makeJar) makeJar(false);
+		else if (source == makeJarWithSource) makeJar(true);
+		else if (source == compileAndRun) runText();
+		else if (source == compile) compile();
+		else if (source == runSelection) runText(true);
+		else if (source == nextError) new Thread() {
+
+			@Override
+			public void run() {
+				nextError(true);
 			}
-		else if (source == cut)
-			getTextArea().cut();
-		else if (source == copy)
-			getTextArea().copy();
-		else if (source == paste)
-			getTextArea().paste();
-		else if (source == undo)
-			getTextArea().undoLastAction();
-		else if (source == redo)
-			getTextArea().redoLastAction();
-		else if (source == find)
-			findOrReplace(false);
-		else if (source == findNext)
-			findDialog.searchOrReplace(false);
-		else if (source == findPrevious)
-			findDialog.searchOrReplace(false, false);
-		else if (source == replace)
-			findOrReplace(true);
-		else if (source == gotoLine)
-			gotoLine();
-		else if (source == toggleBookmark)
-			toggleBookmark();
-		else if (source == listBookmarks)
-			listBookmarks();
+		}.start();
+		else if (source == previousError) new Thread() {
+
+			@Override
+			public void run() {
+				nextError(false);
+			}
+		}.start();
+		else if (source == kill) chooseTaskToKill();
+		else if (source == close) if (tabbed.getTabCount() < 2) processWindowEvent(new WindowEvent(
+			this, WindowEvent.WINDOW_CLOSING));
+		else {
+			if (!handleUnsavedChanges()) return;
+			int index = tabbed.getSelectedIndex();
+			removeTab(index);
+			if (index > 0) index--;
+			switchTo(index);
+		}
+		else if (source == cut) getTextArea().cut();
+		else if (source == copy) getTextArea().copy();
+		else if (source == paste) getTextArea().paste();
+		else if (source == undo) getTextArea().undoLastAction();
+		else if (source == redo) getTextArea().redoLastAction();
+		else if (source == find) findOrReplace(false);
+		else if (source == findNext) findDialog.searchOrReplace(false);
+		else if (source == findPrevious) findDialog.searchOrReplace(false, false);
+		else if (source == replace) findOrReplace(true);
+		else if (source == gotoLine) gotoLine();
+		else if (source == toggleBookmark) toggleBookmark();
+		else if (source == listBookmarks) listBookmarks();
 		else if (source == selectAll) {
 			getTextArea().setCaretPosition(0);
 			getTextArea().moveCaretPosition(getTextArea().getDocument().getLength());
@@ -1085,50 +1093,45 @@ public class TextEditor extends JFrame implements ActionListener,
 		else if (source == chooseTabSize) {
 			commandService.run(ChooseTabSize.class, true, "editor", this);
 		}
-		else if (source == addImport)
-			addImport(null);
-		else if (source == removeUnusedImports)
-			new TokenFunctions(getTextArea()).removeUnusedImports();
-		else if (source == sortImports)
-			new TokenFunctions(getTextArea()).sortImports();
-		else if (source == removeTrailingWhitespace)
-			new TokenFunctions(getTextArea()).removeTrailingWhitespace();
-		else if (source == replaceTabsWithSpaces)
-			getTextArea().convertTabsToSpaces();
-		else if (source == replaceSpacesWithTabs)
-			getTextArea().convertSpacesToTabs();
-		else if (source == clearScreen)
-			getTab().getScreen().setText("");
-		else if (source == zapGremlins)
-			zapGremlins();
-		else if (source == savePreferences)
-			savePreferences();
-		else if (source == openHelp)
-			openHelp(null);
-		else if (source == openHelpWithoutFrames)
-			openHelp(null, false);
+		else if (source == addImport) addImport(null);
+		else if (source == removeUnusedImports) new TokenFunctions(getTextArea())
+			.removeUnusedImports();
+		else if (source == sortImports) new TokenFunctions(getTextArea())
+			.sortImports();
+		else if (source == removeTrailingWhitespace) new TokenFunctions(
+			getTextArea()).removeTrailingWhitespace();
+		else if (source == replaceTabsWithSpaces) getTextArea()
+			.convertTabsToSpaces();
+		else if (source == replaceSpacesWithTabs) getTextArea()
+			.convertSpacesToTabs();
+		else if (source == clearScreen) getTab().getScreen().setText("");
+		else if (source == zapGremlins) zapGremlins();
+		else if (source == savePreferences) savePreferences();
+		else if (source == openHelp) openHelp(null);
+		else if (source == openHelpWithoutFrames) openHelp(null, false);
 		else if (source == openMacroFunctions) try {
 			new MacroFunctions(this).openHelp(getTextArea().getSelectedText());
-		} catch (IOException e) {
+		}
+		catch (IOException e) {
 			handleException(e);
 		}
-		else if (source == extractSourceJar)
-			extractSourceJar();
+		else if (source == extractSourceJar) extractSourceJar();
 		else if (source == openSourceForClass) {
 			String className = getSelectedClassNameOrAsk();
 			if (className != null) try {
 				String path = new FileFunctions(this).getSourcePath(className);
-				if (path != null)
-					open(new File(path));
+				if (path != null) open(new File(path));
 				else {
 					String url = new FileFunctions(this).getSourceURL(className);
 					try {
 						platformService.open(new URL(url));
-					} catch (Throwable e) {
+					}
+					catch (Throwable e) {
 						handleException(e);
 					}
 				}
-			} catch (ClassNotFoundException e) {
+			}
+			catch (ClassNotFoundException e) {
 				error("Could not open source for class " + className);
 			}
 		}
@@ -1159,32 +1162,29 @@ public class TextEditor extends JFrame implements ActionListener,
 			}
 			searchRoot = searchRoot.getParentFile();
 
-			commandService.run(GitGrep.class, true, "editor", this, "searchTerm", searchTerm, "searchRoot", searchRoot);
+			commandService.run(GitGrep.class, true, "editor", this, "searchTerm",
+				searchTerm, "searchRoot", searchRoot);
 		}
 		else if (source == openInGitweb) {
 			EditorPane editorPane = getEditorPane();
-			new FileFunctions(this).openInGitweb(editorPane.file, editorPane.gitDirectory, editorPane.getCaretLineNumber() + 1);
+			new FileFunctions(this).openInGitweb(editorPane.file,
+				editorPane.gitDirectory, editorPane.getCaretLineNumber() + 1);
 		}
 		else if (source == increaseFontSize || source == decreaseFontSize) {
-			getEditorPane().increaseFontSize((float)(source == increaseFontSize ? 1.2 : 1 / 1.2));
+			getEditorPane().increaseFontSize(
+				(float) (source == increaseFontSize ? 1.2 : 1 / 1.2));
 			updateTabAndFontSize(false);
 		}
-		else if (source == nextTab)
-			switchTabRelative(1);
-		else if (source == previousTab)
-			switchTabRelative(-1);
-		else if (handleTabsMenu(source))
-			return;
+		else if (source == nextTab) switchTabRelative(1);
+		else if (source == previousTab) switchTabRelative(-1);
+		else if (handleTabsMenu(source)) return;
 	}
 
 	protected boolean handleTabsMenu(Object source) {
-		if (!(source instanceof JMenuItem))
-			return false;
-		JMenuItem item = (JMenuItem)source;
-		if (!tabsMenuItems.contains(item))
-			return false;
-		for (int i = tabsMenuTabsStart;
-				i < tabsMenu.getItemCount(); i++)
+		if (!(source instanceof JMenuItem)) return false;
+		JMenuItem item = (JMenuItem) source;
+		if (!tabsMenuItems.contains(item)) return false;
+		for (int i = tabsMenuTabsStart; i < tabsMenu.getItemCount(); i++)
 			if (tabsMenu.getItem(i) == item) {
 				switchTo(i - tabsMenuTabsStart);
 				return true;
@@ -1204,10 +1204,12 @@ public class TextEditor extends JFrame implements ActionListener,
 		setTitle();
 		editorPane.checkForOutsideChanges();
 		SwingUtilities.invokeLater(new Runnable() {
+
 			@Override
 			public void run() {
 				editorPane.setLanguageByFileName(editorPane.getFileName());
-				toggleWhiteSpaceLabeling.setSelected(((RSyntaxTextArea)editorPane).isWhitespaceVisible());
+				toggleWhiteSpaceLabeling.setSelected(((RSyntaxTextArea) editorPane)
+					.isWhitespaceVisible());
 			}
 		});
 	}
@@ -1222,28 +1224,29 @@ public class TextEditor extends JFrame implements ActionListener,
 		// override search pattern only if
 		// there is sth. selected
 		String selection = getTextArea().getSelectedText();
-		if (selection != null)
-			findDialog.setSearchPattern(selection);
+		if (selection != null) findDialog.setSearchPattern(selection);
 
 		findDialog.show(replace);
 	}
 
 	public void gotoLine() {
-		String line = JOptionPane.showInputDialog(this, "Line:",
-			"Goto line...", JOptionPane.QUESTION_MESSAGE);
-		if (line == null)
-			return;
+		String line =
+			JOptionPane.showInputDialog(this, "Line:", "Goto line...",
+				JOptionPane.QUESTION_MESSAGE);
+		if (line == null) return;
 		try {
 			gotoLine(Integer.parseInt(line));
-		} catch (BadLocationException e) {
+		}
+		catch (BadLocationException e) {
 			error("Line number out of range: " + line);
-		} catch (NumberFormatException e) {
+		}
+		catch (NumberFormatException e) {
 			error("Invalid line number: " + line);
 		}
 	}
 
 	public void gotoLine(int line) throws BadLocationException {
-		getTextArea().setCaretPosition(getTextArea().getLineStartOffset(line-1));
+		getTextArea().setCaretPosition(getTextArea().getLineStartOffset(line - 1));
 	}
 
 	public void toggleBookmark() {
@@ -1251,8 +1254,7 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public void listBookmarks() {
-		Vector<EditorPane.Bookmark> bookmarks =
-			new Vector<EditorPane.Bookmark>();
+		Vector<EditorPane.Bookmark> bookmarks = new Vector<EditorPane.Bookmark>();
 		for (int i = 0; i < tabbed.getTabCount(); i++)
 			getEditorPane(i).getBookmarks(i, bookmarks);
 		BookmarkDialog dialog = new BookmarkDialog(this, bookmarks);
@@ -1265,37 +1267,35 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	public boolean reload(String message) {
 		File file = getEditorPane().file;
-		if (file == null || !file.exists())
-			return true;
+		if (file == null || !file.exists()) return true;
 
 		boolean modified = getEditorPane().fileChanged();
 		String[] options = { "Reload", "Do not reload" };
-		if (modified)
-			options[0] = "Reload (discarding changes)";
+		if (modified) options[0] = "Reload (discarding changes)";
 		switch (JOptionPane.showOptionDialog(this, message, "Reload",
-			JOptionPane.DEFAULT_OPTION, JOptionPane.WARNING_MESSAGE,
-			null, options, options[0])) {
-		case 0:
-			try {
-				getEditorPane().open(file);
-				return true;
-			} catch (IOException e) {
-				error("Could not reload " + file.getPath());
-			}
-			break;
+			JOptionPane.DEFAULT_OPTION, JOptionPane.WARNING_MESSAGE, null, options,
+			options[0])) {
+			case 0:
+				try {
+					getEditorPane().open(file);
+					return true;
+				}
+				catch (IOException e) {
+					error("Could not reload " + file.getPath());
+				}
+				break;
 		}
 		return false;
 	}
 
 	public Tab getTab() {
 		int index = tabbed.getSelectedIndex();
-		if (index < 0)
-			return null;
-		return (Tab)tabbed.getComponentAt(index);
+		if (index < 0) return null;
+		return (Tab) tabbed.getComponentAt(index);
 	}
 
 	public Tab getTab(int index) {
-		return (Tab)tabbed.getComponentAt(index);
+		return (Tab) tabbed.getComponentAt(index);
 	}
 
 	public class Tab extends JSplitPane {
@@ -1327,8 +1327,11 @@ public class TextEditor extends JFrame implements ActionListener,
 			bc.fill = GridBagConstraints.NONE;
 			runit = new JButton("Run");
 			runit.addActionListener(new ActionListener() {
+
 				@Override
-				public void actionPerformed(ActionEvent ae) { runText(); }
+				public void actionPerformed(ActionEvent ae) {
+					runText();
+				}
 			});
 			bottom.add(runit, bc);
 
@@ -1336,6 +1339,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			killit = new JButton("Kill");
 			killit.setEnabled(false);
 			killit.addActionListener(new ActionListener() {
+
 				@Override
 				public void actionPerformed(ActionEvent ae) {
 					kill();
@@ -1354,6 +1358,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			bc.anchor = GridBagConstraints.NORTHEAST;
 			toggleErrors = new JButton("Show Errors");
 			toggleErrors.addActionListener(new ActionListener() {
+
 				@Override
 				public void actionPerformed(ActionEvent e) {
 					toggleErrors();
@@ -1367,12 +1372,11 @@ public class TextEditor extends JFrame implements ActionListener,
 			bc.anchor = GridBagConstraints.NORTHEAST;
 			JButton clear = new JButton("Clear");
 			clear.addActionListener(new ActionListener() {
+
 				@Override
 				public void actionPerformed(ActionEvent ae) {
-					if (showingErrors)
-						errorScreen.setText("");
-					else
-						screen.setText("");
+					if (showingErrors) errorScreen.setText("");
+					else screen.setText("");
 				}
 			});
 			bottom.add(clear, bc);
@@ -1403,10 +1407,10 @@ public class TextEditor extends JFrame implements ActionListener,
 		 */
 		public void loadPreferences() {
 			editorPane.setTabSize(getTabSizeSetting());
-			editorPane.setFontSize(prefService.getFloat(FONT_SIZE_PREFS,
-				editorPane.getFontSize()));
-			editorPane.setLineWrap(prefService.getBoolean(LINE_WRAP_PREFS,
-				editorPane.getLineWrap()));
+			editorPane.setFontSize(prefService.getFloat(FONT_SIZE_PREFS, editorPane
+				.getFontSize()));
+			editorPane.setLineWrap(prefService.getBoolean(LINE_WRAP_PREFS, editorPane
+				.getLineWrap()));
 			editorPane.setTabsEmulated(prefService.getBoolean(TABS_EMULATED_PREFS,
 				editorPane.getTabsEmulated()));
 		}
@@ -1420,6 +1424,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		private void restore() {
 			SwingUtilities.invokeLater(new Runnable() {
+
 				@Override
 				public void run() {
 					editorPane.setEditable(true);
@@ -1443,19 +1448,17 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 
 		public void showErrors() {
-			if (!showingErrors)
-				toggleErrors();
-			else if (scroll.getViewport().getView() == null)
-				scroll.setViewportView(errorScreen);
+			if (!showingErrors) toggleErrors();
+			else if (scroll.getViewport().getView() == null) scroll
+				.setViewportView(errorScreen);
 		}
 
 		public void showOutput() {
-			if (showingErrors)
-				toggleErrors();
+			if (showingErrors) toggleErrors();
 		}
 
 		public JTextArea getScreen() {
-			return showingErrors ? errorScreen: screen;
+			return showingErrors ? errorScreen : screen;
 		}
 
 		boolean isExecuting() {
@@ -1463,9 +1466,8 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 
 		String getTitle() {
-			return (editorPane.fileChanged() ? "*" : "")
-				+ editorPane.getFileName()
-				+ (isExecuting() ? " (Running)" : "");
+			return (editorPane.fileChanged() ? "*" : "") + editorPane.getFileName() +
+				(isExecuting() ? " (Running)" : "");
 		}
 
 		/** Invoke in the context of the event dispatch thread. */
@@ -1473,8 +1475,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			prepare();
 			final JTextAreaWriter output =
 				new JTextAreaWriter(this.screen, TextEditor.this.log);
-			final JTextAreaWriter errors =
-				new JTextAreaWriter(errorScreen, log);
+			final JTextAreaWriter errors = new JTextAreaWriter(errorScreen, log);
 			final File file = getEditorPane().file;
 			// Pipe current text into the runScript:
 			final PipedInputStream pi = new PipedInputStream();
@@ -1482,27 +1483,30 @@ public class TextEditor extends JFrame implements ActionListener,
 			// The Executer creates a Thread that
 			// does the reading from PipedInputStream
 			this.executer = new TextEditor.Executer(output, errors) {
+
 				@Override
 				public void execute() {
 					try {
-						evalScript(file == null ? getEditorPane().getFileName()
-								: file.getAbsolutePath(),
-								new InputStreamReader(pi), output, errors);
+						evalScript(file == null ? getEditorPane().getFileName() : file
+							.getAbsolutePath(), new InputStreamReader(pi), output, errors);
 						output.flush();
 						errors.flush();
 						markCompileEnd();
-					} catch (Throwable t) {
+					}
+					catch (Throwable t) {
 						output.flush();
 						errors.flush();
-						if (t instanceof ScriptException &&
-								t.getCause() != null &&
-								t.getCause().getClass().getName().endsWith("CompileError")) {
+						if (t instanceof ScriptException && t.getCause() != null &&
+							t.getCause().getClass().getName().endsWith("CompileError"))
+						{
 							errorScreen.append("Compilation failed");
 							showErrors();
-						} else {
+						}
+						else {
 							handleException(t);
 						}
-					} finally {
+					}
+					finally {
 						restore();
 					}
 				}
@@ -1517,26 +1521,36 @@ public class TextEditor extends JFrame implements ActionListener,
 						error("Selection required!");
 						text = null;
 					}
-					else
-						text = selected + "\n"; // Ensure code blocks are terminated
-				} else {
+					else text = selected + "\n"; // Ensure code blocks are terminated
+				}
+				else {
 					text = editorPane.getText();
 				}
 				new Thread() {
-					{ setPriority(Thread.NORM_PRIORITY); }
+
+					{
+						setPriority(Thread.NORM_PRIORITY);
+					}
+
 					@Override
 					public void run() {
 						PrintWriter pw = new PrintWriter(po);
 						pw.write(text);
 						pw.flush(); // will lock and wait in some cases
-						try { po.close(); }
-						catch (Throwable tt) { tt.printStackTrace(); }
+						try {
+							po.close();
+						}
+						catch (Throwable tt) {
+							tt.printStackTrace();
+						}
 						pw.close();
 					}
 				}.start();
-			} catch (Throwable t) {
+			}
+			catch (Throwable t) {
 				t.printStackTrace();
-			} finally {
+			}
+			finally {
 				// Re-enable when all text to send has been sent
 				editorPane.setEditable(true);
 			}
@@ -1549,13 +1563,18 @@ public class TextEditor extends JFrame implements ActionListener,
 			// Give it 3 seconds. Then, stop it.
 			final long now = System.currentTimeMillis();
 			new Thread() {
-				{ setPriority(Thread.NORM_PRIORITY); }
+
+				{
+					setPriority(Thread.NORM_PRIORITY);
+				}
+
 				@Override
 				public void run() {
 					while (System.currentTimeMillis() - now < 3000)
 						try {
 							Thread.sleep(100);
-						} catch (InterruptedException e) {}
+						}
+						catch (InterruptedException e) {}
 					if (null != executer) executer.obliterate();
 					restore();
 
@@ -1565,17 +1584,16 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public static boolean isBinary(File file) {
-		if (file == null)
-			return false;
-		// heuristic: read the first up to 8000 bytes, and say that it is binary if it contains a NUL
+		if (file == null) return false;
+		// heuristic: read the first up to 8000 bytes, and say that it is binary if
+		// it contains a NUL
 		try {
 			FileInputStream in = new FileInputStream(file);
 			int left = 8000;
 			byte[] buffer = new byte[left];
 			while (left > 0) {
 				int count = in.read(buffer, 0, left);
-				if (count < 0)
-					break;
+				if (count < 0) break;
 				for (int i = 0; i < count; i++)
 					if (buffer[i] == 0) {
 						in.close();
@@ -1585,12 +1603,16 @@ public class TextEditor extends JFrame implements ActionListener,
 			}
 			in.close();
 			return false;
-		} catch (IOException e) {
+		}
+		catch (IOException e) {
 			return false;
 		}
 	}
 
-	/** Open a new tab with some content; the languageExtension is like ".java", ".py", etc. */
+	/**
+	 * Open a new tab with some content; the languageExtension is like ".java",
+	 * ".py", etc.
+	 */
 	public Tab newTab(String content, String language) {
 		Tab tab = open(null);
 		if (null != language && language.length() > 0) {
@@ -1620,28 +1642,28 @@ public class TextEditor extends JFrame implements ActionListener,
 			synchronized (tab.editorPane) {
 				tab.editorPane.open(file);
 				if (wasNew) {
-					int index = tabbed.getSelectedIndex()
-						+ tabsMenuTabsStart;
-					tabsMenu.getItem(index)
-						.setText(tab.editorPane.getFileName());
+					int index = tabbed.getSelectedIndex() + tabsMenuTabsStart;
+					tabsMenu.getItem(index).setText(tab.editorPane.getFileName());
 				}
 				else {
 					tabbed.addTab("", tab);
 					switchTo(tabbed.getTabCount() - 1);
-					tabsMenuItems.add(addToMenu(tabsMenu,
-						tab.editorPane.getFileName(), 0, 0));
+					tabsMenuItems.add(addToMenu(tabsMenu, tab.editorPane.getFileName(),
+						0, 0));
 				}
 				setFileName(tab.editorPane.file);
 				try {
 					updateTabAndFontSize(true);
-				} catch (NullPointerException e) {
+				}
+				catch (NullPointerException e) {
 					/* ignore */
 				}
 			}
 			if (file != null) openRecent.add(file.getAbsolutePath());
 
 			return tab;
-		} catch (FileNotFoundException e) {
+		}
+		catch (FileNotFoundException e) {
 			e.printStackTrace();
 			error("The file '" + file + "' was not found.");
 		}
@@ -1671,15 +1693,11 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	public boolean saveAs(String path, boolean askBeforeReplacing) {
 		File file = new File(path);
-		if (file.exists() && askBeforeReplacing &&
-				JOptionPane.showConfirmDialog(this,
-					"Do you want to replace " + path + "?",
-					"Replace " + path + "?",
-					JOptionPane.YES_NO_OPTION)
-				!= JOptionPane.YES_OPTION)
-			return false;
-		if (!write(file))
-			return false;
+		if (file.exists() &&
+			askBeforeReplacing &&
+			JOptionPane.showConfirmDialog(this, "Do you want to replace " + path +
+				"?", "Replace " + path + "?", JOptionPane.YES_NO_OPTION) != JOptionPane.YES_OPTION) return false;
+		if (!write(file)) return false;
 		setFileName(file);
 		openRecent.add(path);
 		return true;
@@ -1687,10 +1705,8 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	public boolean save() {
 		File file = getEditorPane().file;
-		if (file == null)
-			return saveAs();
-		if (!write(file))
-			return false;
+		if (file == null) return saveAs();
+		if (!write(file)) return false;
 		setTitle();
 		return true;
 	}
@@ -1699,7 +1715,8 @@ public class TextEditor extends JFrame implements ActionListener,
 		try {
 			getEditorPane().write(file);
 			return true;
-		} catch (IOException e) {
+		}
+		catch (IOException e) {
 			error("Could not save " + file.getName());
 			e.printStackTrace();
 			return false;
@@ -1714,83 +1731,80 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		String name = getEditorPane().getFileName();
 		String ext = FileUtils.getExtension(name);
-		if (!"".equals(ext))
-			name = name.substring(0, name.length()
-				- ext.length());
-		if (name.indexOf('_') < 0)
-			name += "_";
+		if (!"".equals(ext)) name = name.substring(0, name.length() - ext.length());
+		if (name.indexOf('_') < 0) name += "_";
 		name += ".jar";
 
 		final File selectedFile = uiService.chooseFile(file, FileWidget.SAVE_STYLE);
 		if (selectedFile == null) return false;
 		if (selectedFile.exists() &&
-				JOptionPane.showConfirmDialog(this,
-					"Do you want to replace " + selectedFile + "?",
-					"Replace " + selectedFile + "?",
-					JOptionPane.YES_NO_OPTION)
-				!= JOptionPane.YES_OPTION)
-			return false;
+			JOptionPane.showConfirmDialog(this, "Do you want to replace " +
+				selectedFile + "?", "Replace " + selectedFile + "?",
+				JOptionPane.YES_NO_OPTION) != JOptionPane.YES_OPTION) return false;
 		try {
 			makeJar(selectedFile, includeSources);
 			return true;
-		} catch (IOException e) {
+		}
+		catch (IOException e) {
 			e.printStackTrace();
-			error("Could not write " + selectedFile
-					+ ": " + e.getMessage());
+			error("Could not write " + selectedFile + ": " + e.getMessage());
 			return false;
 		}
 	}
 
 	public void makeJar(final File file, final boolean includeSources)
-			throws IOException {
-		if (!handleUnsavedChanges(true))
-			return;
+		throws IOException
+	{
+		if (!handleUnsavedChanges(true)) return;
 
-		final ScriptEngine interpreter =
-			getCurrentLanguage().getScriptEngine();
+		final ScriptEngine interpreter = getCurrentLanguage().getScriptEngine();
 		if (interpreter instanceof JavaEngine) {
 			final JavaEngine java = (JavaEngine) interpreter;
 			final JTextAreaWriter errors = new JTextAreaWriter(errorScreen, log);
 			markCompileStart();
 			getTab().showErrors();
 			new Thread() {
+
 				@Override
 				public void run() {
 					java.makeJar(getEditorPane().file, includeSources, file, errors);
-					errorScreen.insert("Compilation finished.\n", errorScreen.getDocument().getLength());
+					errorScreen.insert("Compilation finished.\n", errorScreen
+						.getDocument().getLength());
 					markCompileEnd();
 				}
 			}.start();
 		}
 	}
 
-	static void getClasses(File directory,
-			List<String> paths, List<String> names) {
+	static void
+		getClasses(File directory, List<String> paths, List<String> names)
+	{
 		getClasses(directory, paths, names, "");
 	}
 
-	static void getClasses(File directory,
-			List<String> paths, List<String> names, String prefix) {
-		if (!prefix.equals(""))
-			prefix += "/";
+	static void getClasses(File directory, List<String> paths,
+		List<String> names, String prefix)
+	{
+		if (!prefix.equals("")) prefix += "/";
 		for (File file : directory.listFiles())
-			if (file.isDirectory())
-				getClasses(file, paths, names,
-						prefix + file.getName());
+			if (file.isDirectory()) getClasses(file, paths, names, prefix +
+				file.getName());
 			else {
 				paths.add(file.getAbsolutePath());
 				names.add(prefix + file.getName());
 			}
 	}
 
-	static void writeJarEntry(JarOutputStream out, String name,
-			byte[] buf) throws IOException {
+	static void writeJarEntry(JarOutputStream out, String name, byte[] buf)
+		throws IOException
+	{
 		try {
 			JarEntry entry = new JarEntry(name);
 			out.putNextEntry(entry);
 			out.write(buf, 0, buf.length);
 			out.closeEntry();
-		} catch (ZipException e) {
+		}
+		catch (ZipException e) {
 			e.printStackTrace();
 			throw new IOException(e.getMessage());
 		}
@@ -1799,7 +1813,7 @@ public class TextEditor extends JFrame implements ActionListener,
 	static byte[] readFile(String fileName) throws IOException {
 		File file = new File(fileName);
 		InputStream in = new FileInputStream(file);
-		byte[] buffer = new byte[(int)file.length()];
+		byte[] buffer = new byte[(int) file.length()];
 		in.read(buffer);
 		in.close();
 		return buffer;
@@ -1807,10 +1821,8 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	static void deleteRecursively(File directory) {
 		for (File file : directory.listFiles())
-			if (file.isDirectory())
-				deleteRecursively(file);
-			else
-				file.delete();
+			if (file.isDirectory()) deleteRecursively(file);
+			else file.delete();
 		directory.delete();
 	}
 
@@ -1825,33 +1837,33 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	void updateLanguageMenu(ScriptLanguage language) {
 		JMenuItem item = languageMenuItems.get(language);
-		if (item == null)
-			item = noneLanguageItem;
+		if (item == null) item = noneLanguageItem;
 		if (!item.isSelected()) {
 			item.setSelected(true);
 		}
 
 		final boolean isRunnable = item != noneLanguageItem;
-		final boolean isCompileable = language != null && language.isCompiledLanguage();
+		final boolean isCompileable =
+			language != null && language.isCompiledLanguage();
 
 		runMenu.setVisible(isRunnable);
-		compileAndRun.setText(isCompileable ?
-			"Compile and Run" : "Run");
+		compileAndRun.setText(isCompileable ? "Compile and Run" : "Run");
 		compileAndRun.setEnabled(isRunnable);
-		runSelection.setVisible(isRunnable &&
-				!isCompileable);
+		runSelection.setVisible(isRunnable && !isCompileable);
 		compile.setVisible(isCompileable);
 		autoSave.setVisible(isCompileable);
 		makeJar.setVisible(isCompileable);
 		makeJarWithSource.setVisible(isCompileable);
 
-		boolean isJava = language != null && language.getLanguageName().equals("Java");
+		boolean isJava =
+			language != null && language.getLanguageName().equals("Java");
 		addImport.setVisible(isJava);
 		removeUnusedImports.setVisible(isJava);
 		sortImports.setVisible(isJava);
 		openSourceForMenuItem.setVisible(isJava);
 
-		boolean isMacro = language != null && language.getLanguageName().equals("ImageJ Macro");
+		boolean isMacro =
+			language != null && language.getLanguageName().equals("ImageJ Macro");
 		openMacroFunctions.setVisible(isMacro);
 		openSourceForClass.setVisible(!isMacro);
 
@@ -1860,8 +1872,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		nextError.setVisible(!isMacro && isRunnable);
 		previousError.setVisible(!isMacro && isRunnable);
 
-		if (getEditorPane() == null)
-			return;
+		if (getEditorPane() == null) return;
 		boolean isInGit = getEditorPane().getGitDirectory() != null;
 		gitMenu.setVisible(isInGit);
 
@@ -1873,7 +1884,8 @@ public class TextEditor extends JFrame implements ActionListener,
 		if (pane.currentLanguage == null) return;
 
 		if (setByLanguage) {
-			final boolean isPython = pane.currentLanguage.getLanguageName().equals("Python");
+			final boolean isPython =
+				pane.currentLanguage.getLanguageName().equals("Python");
 			pane.setTabSize(isPython ? 4 : getTabSizeSetting());
 		}
 
@@ -1883,25 +1895,26 @@ public class TextEditor extends JFrame implements ActionListener,
 			JMenuItem item = tabSizeMenu.getItem(i);
 			if (item == chooseTabSize) {
 				item.setSelected(!defaultSize);
-				item.setText("Other" + (defaultSize ? "" : " (" + tabSize + ")") + "...");
+				item.setText("Other" + (defaultSize ? "" : " (" + tabSize + ")") +
+					"...");
 			}
 			else if (tabSize == Integer.parseInt(item.getText())) {
 				item.setSelected(true);
 				defaultSize = true;
 			}
 		}
-		int fontSize = (int)pane.getFontSize();
+		int fontSize = (int) pane.getFontSize();
 		defaultSize = false;
 		for (int i = 0; i < fontSizeMenu.getItemCount(); i++) {
 			JMenuItem item = fontSizeMenu.getItem(i);
 			if (item == chooseFontSize) {
 				item.setSelected(!defaultSize);
-				item.setText("Other" + (defaultSize ? "" : " (" + fontSize + ")") + "...");
+				item.setText("Other" + (defaultSize ? "" : " (" + fontSize + ")") +
+					"...");
 				continue;
 			}
 			String label = item.getText();
-			if (label.endsWith(" pt"))
-				label = label.substring(0, label.length() - 3);
+			if (label.endsWith(" pt")) label = label.substring(0, label.length() - 3);
 			if (fontSize == Integer.parseInt(label)) {
 				item.setSelected(true);
 				defaultSize = true;
@@ -1921,20 +1934,20 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	synchronized void setTitle() {
 		final Tab tab = getTab();
-		if (null == tab || null == tab.editorPane)
-			return;
+		if (null == tab || null == tab.editorPane) return;
 		final boolean fileChanged = tab.editorPane.fileChanged();
 		final String fileName = tab.editorPane.getFileName();
-		final String title = (fileChanged ? "*" : "") + fileName
-			+ (executingTasks.isEmpty() ? "" : " (Running)");
+		final String title =
+			(fileChanged ? "*" : "") + fileName +
+				(executingTasks.isEmpty() ? "" : " (Running)");
 		SwingUtilities.invokeLater(new Runnable() {
+
 			@Override
 			public void run() {
 				setTitle(title); // to the main window
 				// Update all tabs: could have changed
-				for (int i=0; i<tabbed.getTabCount(); i++)
-					tabbed.setTitleAt(i,
-						((Tab)tabbed.getComponentAt(i)).getTitle());
+				for (int i = 0; i < tabbed.getTabCount(); i++)
+					tabbed.setTitleAt(i, ((Tab) tabbed.getComponentAt(i)).getTitle());
 			}
 		});
 	}
@@ -1945,17 +1958,20 @@ public class TextEditor extends JFrame implements ActionListener,
 		int index = tabsMenuTabsStart + tabbed.getSelectedIndex();
 		if (index < tabsMenu.getItemCount()) {
 			JMenuItem item = tabsMenu.getItem(index);
-			if (item != null)
-				item.setText(title);
+			if (item != null) item.setText(title);
 		}
 	}
 
 	private ArrayList<Executer> executingTasks = new ArrayList<Executer>();
 
-	/** Generic Thread that keeps a starting time stamp,
-	 *  sets the priority to normal and starts itself. */
+	/**
+	 * Generic Thread that keeps a starting time stamp, sets the priority to
+	 * normal and starts itself.
+	 */
 	public abstract class Executer extends ThreadGroup {
+
 		JTextAreaWriter output, errors;
+
 		Executer(final JTextAreaWriter output, final JTextAreaWriter errors) {
 			super("Script Editor Run :: " + new Date().toString());
 			this.output = output;
@@ -1967,10 +1983,12 @@ public class TextEditor extends JFrame implements ActionListener,
 			kill.setEnabled(true);
 			// Fork a task, as a part of this ThreadGroup
 			new Thread(this, getName()) {
+
 				{
 					setPriority(Thread.NORM_PRIORITY);
 					start();
 				}
+
 				@Override
 				public void run() {
 					try {
@@ -1996,18 +2014,20 @@ public class TextEditor extends JFrame implements ActionListener,
 									// Do not wait on the stack slice selector thread.
 									break;
 								}
-							} catch (InterruptedException ie) {}
+							}
+							catch (InterruptedException ie) {}
 						}
-					} catch (Throwable t) {
+					}
+					catch (Throwable t) {
 						handleException(t);
-					} finally {
+					}
+					finally {
 						executingTasks.remove(Executer.this);
 						try {
-							if (null != output)
-								output.shutdown();
-							if (null != errors)
-								errors.shutdown();
-						} catch (Exception e) {
+							if (null != output) output.shutdown();
+							if (null != errors) errors.shutdown();
+						}
+						catch (Exception e) {
 							handleException(e);
 						}
 						// Leave kill menu item enabled if other tasks are running
@@ -2046,16 +2066,18 @@ public class TextEditor extends JFrame implements ActionListener,
 			return threads;
 		}
 
-		/** Totally destroy/stop all threads in this and all recursive thread subgroups. Will remove itself from the executingTasks list. */
+		/**
+		 * Totally destroy/stop all threads in this and all recursive thread
+		 * subgroups. Will remove itself from the executingTasks list.
+		 */
 		@SuppressWarnings("deprecation")
 		void obliterate() {
 			try {
 				// Stop printing to the screen
-				if (null != output)
-					output.shutdownNow();
-				if (null != errors)
-					errors.shutdownNow();
-			} catch (Exception e) {
+				if (null != output) output.shutdownNow();
+				if (null != errors) errors.shutdownNow();
+			}
+			catch (Exception e) {
 				e.printStackTrace();
 			}
 			for (Thread thread : getAllThreads()) {
@@ -2063,7 +2085,8 @@ public class TextEditor extends JFrame implements ActionListener,
 					thread.interrupt();
 					Thread.yield(); // give it a chance
 					thread.stop();
-				} catch (Throwable t) {
+				}
+				catch (Throwable t) {
 					t.printStackTrace();
 				}
 			}
@@ -2083,8 +2106,8 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public void kill(Executer executer) {
-		for (int i=0; i<tabbed.getTabCount(); i++) {
-			Tab tab = (Tab)tabbed.getComponentAt(i);
+		for (int i = 0; i < tabbed.getTabCount(); i++) {
+			Tab tab = (Tab) tabbed.getComponentAt(i);
 			if (executer == tab.executer) {
 				tab.kill();
 				break;
@@ -2092,7 +2115,10 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 	}
 
-	/** Query the list of running scripts and provide a dialog to choose one and kill it. */
+	/**
+	 * Query the list of running scripts and provide a dialog to choose one and
+	 * kill it.
+	 */
 	public void chooseTaskToKill() {
 		if (executingTasks.size() == 0) {
 			error("\nNo running scripts\n");
@@ -2112,8 +2138,7 @@ public class TextEditor extends JFrame implements ActionListener,
 				error("Cannot run selection of compiled language!");
 				return;
 			}
-			if (handleUnsavedChanges(true))
-				runScript();
+			if (handleUnsavedChanges(true)) runScript();
 			return;
 		}
 		final ScriptLanguage currentLanguage = getCurrentLanguage();
@@ -2128,16 +2153,15 @@ public class TextEditor extends JFrame implements ActionListener,
 			Tab tab = getTab();
 			tab.showOutput();
 			tab.execute(selectionOnly);
-		} catch (Throwable t) {
+		}
+		catch (Throwable t) {
 			t.printStackTrace();
 		}
 	}
 
 	public void runScript() {
-		if (isCompiled())
-			getTab().showErrors();
-		else
-			getTab().showOutput();
+		if (isCompiled()) getTab().showErrors();
+		else getTab().showOutput();
 
 		markCompileStart();
 		final JTextAreaWriter output = new JTextAreaWriter(getTab().screen, log);
@@ -2145,11 +2169,14 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		final File file = getEditorPane().file;
 		new TextEditor.Executer(output, errors) {
+
 			@Override
 			public void execute() {
 				Reader reader = null;
 				try {
-					reader = evalScript(getEditorPane().file.getPath(), new FileReader(file), output, errors);
+					reader =
+						evalScript(getEditorPane().file.getPath(), new FileReader(file),
+							output, errors);
 
 					output.flush();
 					errors.flush();
@@ -2173,21 +2200,21 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public void compile() {
-		if (!handleUnsavedChanges(true))
-			return;
+		if (!handleUnsavedChanges(true)) return;
 
-		final ScriptEngine interpreter =
-			getCurrentLanguage().getScriptEngine();
+		final ScriptEngine interpreter = getCurrentLanguage().getScriptEngine();
 		if (interpreter instanceof JavaEngine) {
 			final JavaEngine java = (JavaEngine) interpreter;
 			final JTextAreaWriter errors = new JTextAreaWriter(errorScreen, log);
 			markCompileStart();
 			getTab().showErrors();
 			new Thread() {
+
 				@Override
 				public void run() {
 					java.compile(getEditorPane().file, errors);
-					errorScreen.insert("Compilation finished.\n", errorScreen.getDocument().getLength());
+					errorScreen.insert("Compilation finished.\n", errorScreen
+						.getDocument().getLength());
 					markCompileEnd();
 				}
 			}.start();
@@ -2197,19 +2224,17 @@ public class TextEditor extends JFrame implements ActionListener,
 	public String getSelectedTextOrAsk(String label) {
 		String selection = getTextArea().getSelectedText();
 		if (selection == null || selection.indexOf('\n') >= 0) {
-			selection = JOptionPane.showInputDialog(this,
-				label + ":", label + "...",
-				JOptionPane.QUESTION_MESSAGE);
-			if (selection == null)
-				return null;
+			selection =
+				JOptionPane.showInputDialog(this, label + ":", label + "...",
+					JOptionPane.QUESTION_MESSAGE);
+			if (selection == null) return null;
 		}
 		return selection;
 	}
 
 	public String getSelectedClassNameOrAsk() {
 		String className = getSelectedTextOrAsk("Class name");
-		if (className != null)
-			className = className.trim();
+		if (className != null) className = className.trim();
 		return className;
 	}
 
@@ -2222,14 +2247,16 @@ public class TextEditor extends JFrame implements ActionListener,
 	public void markCompileStart() {
 		errorHandler = null;
 
-		String started = "Started " + getEditorPane().getFileName() + " at " + new Date() + "\n";
+		String started =
+			"Started " + getEditorPane().getFileName() + " at " + new Date() + "\n";
 		int offset = errorScreen.getDocument().getLength();
 		append(errorScreen, started);
 		append(getTab().screen, started);
 		compileStartOffset = errorScreen.getDocument().getLength();
 		try {
 			compileStartPosition = errorScreen.getDocument().createPosition(offset);
-		} catch (BadLocationException e) {
+		}
+		catch (BadLocationException e) {
 			handleException(e);
 		}
 		ExceptionHandler.addThread(Thread.currentThread(), this);
@@ -2237,13 +2264,13 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	public void markCompileEnd() {
 		if (errorHandler == null) {
-			errorHandler = new ErrorHandler(getCurrentLanguage(),
-				errorScreen, compileStartPosition.getOffset());
-			if (errorHandler.getErrorCount() > 0)
-				getTab().showErrors();
+			errorHandler =
+				new ErrorHandler(getCurrentLanguage(), errorScreen,
+					compileStartPosition.getOffset());
+			if (errorHandler.getErrorCount() > 0) getTab().showErrors();
 		}
-		if (compileStartOffset != errorScreen.getDocument().getLength())
-			getTab().showErrors();
+		if (compileStartOffset != errorScreen.getDocument().getLength()) getTab()
+			.showErrors();
 		if (getTab().showingErrors) {
 			errorHandler.scrollToVisible(compileStartOffset);
 		}
@@ -2252,14 +2279,14 @@ public class TextEditor extends JFrame implements ActionListener,
 	public boolean nextError(boolean forward) {
 		if (errorHandler != null && errorHandler.nextError(forward)) try {
 			File file = new File(errorHandler.getPath());
-			if (!file.isAbsolute())
-				file = getFileForBasename(file.getName());
+			if (!file.isAbsolute()) file = getFileForBasename(file.getName());
 			errorHandler.markLine();
 			switchTo(file, errorHandler.getLine());
 			getTab().showErrors();
 			errorScreen.invalidate();
 			return true;
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			handleException(e);
 		}
 		return false;
@@ -2270,14 +2297,15 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public void switchTo(File file, final int lineNumber) {
-		if (!editorPaneContainsFile(getEditorPane(), file))
-			switchTo(file);
+		if (!editorPaneContainsFile(getEditorPane(), file)) switchTo(file);
 		SwingUtilities.invokeLater(new Runnable() {
+
 			@Override
 			public void run() {
 				try {
 					gotoLine(lineNumber);
-				} catch (BadLocationException e) {
+				}
+				catch (BadLocationException e) {
 					// ignore
 				}
 			}
@@ -2294,8 +2322,7 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public void switchTo(int index) {
-		if (index == tabbed.getSelectedIndex())
-			return;
+		if (index == tabbed.getSelectedIndex()) return;
 		tabbed.setSelectedIndex(index);
 	}
 
@@ -2303,8 +2330,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		int index = tabbed.getSelectedIndex();
 		int count = tabbed.getTabCount();
 		index = ((index + delta) % count);
-		if (index < 0)
-			index += count;
+		if (index < 0) index += count;
 		switchTo(index);
 	}
 
@@ -2317,11 +2343,10 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	boolean editorPaneContainsFile(EditorPane editorPane, File file) {
 		try {
-			return file != null && editorPane != null &&
-				editorPane.file != null &&
-				file.getCanonicalFile()
-				.equals(editorPane.file.getCanonicalFile());
-		} catch (IOException e) {
+			return file != null && editorPane != null && editorPane.file != null &&
+				file.getCanonicalFile().equals(editorPane.file.getCanonicalFile());
+		}
+		catch (IOException e) {
 			return false;
 		}
 	}
@@ -2332,21 +2357,18 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	public File getFileForBasename(String baseName) {
 		File file = getFile();
-		if (file != null && file.getName().equals(baseName))
-			return file;
+		if (file != null && file.getName().equals(baseName)) return file;
 		for (int i = 0; i < tabbed.getTabCount(); i++) {
 			file = getEditorPane(i).file;
-			if (file != null && file.getName().equals(baseName))
-				return file;
+			if (file != null && file.getName().equals(baseName)) return file;
 		}
 		return null;
 	}
 
 	public void addImport(String className) {
-		if (className == null)
-			className = getSelectedClassNameOrAsk();
-		if (className != null)
-			new TokenFunctions(getTextArea()).addImport(className.trim());
+		if (className == null) className = getSelectedClassNameOrAsk();
+		if (className != null) new TokenFunctions(getTextArea())
+			.addImport(className.trim());
 	}
 
 	public void openHelp(String className) {
@@ -2354,14 +2376,12 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	public void openHelp(String className, boolean withFrames) {
-		if (className == null)
-			className = getSelectedClassNameOrAsk();
+		if (className == null) className = getSelectedClassNameOrAsk();
 	}
 
 	public void extractSourceJar() {
 		File file = openWithDialog(null);
-		if (file != null)
-			extractSourceJar(file);
+		if (file != null) extractSourceJar(file);
 	}
 
 	public void extractSourceJar(File file) {
@@ -2371,18 +2391,18 @@ public class TextEditor extends JFrame implements ActionListener,
 				uiService.chooseFile(new File(System.getProperty("user.home")),
 					FileWidget.DIRECTORY_STYLE);
 			if (workspace == null) return;
-			List<String> paths = functions.extractSourceJar(file.getAbsolutePath(), workspace);
+			List<String> paths =
+				functions.extractSourceJar(file.getAbsolutePath(), workspace);
 			for (String path : paths)
 				if (!functions.isBinaryFile(path)) {
 					open(new File(path));
 					EditorPane pane = getEditorPane();
 					new TokenFunctions(pane).removeTrailingWhitespace();
-					if (pane.fileChanged())
-						save();
+					if (pane.fileChanged()) save();
 				}
-		} catch (IOException e) {
-			error("There was a problem opening " + file
-				+ ": " + e.getMessage());
+		}
+		catch (IOException e) {
+			error("There was a problem opening " + file + ": " + e.getMessage());
 		}
 	}
 
@@ -2398,16 +2418,14 @@ public class TextEditor extends JFrame implements ActionListener,
 	 */
 	public void write(String message) {
 		Tab tab = getTab();
-		if (!message.endsWith("\n"))
-			message += "\n";
+		if (!message.endsWith("\n")) message += "\n";
 		tab.screen.insert(message, tab.screen.getDocument().getLength());
 	}
 
 	public void writeError(String message) {
 		Tab tab = getTab();
 		tab.showErrors();
-		if (!message.endsWith("\n"))
-			message += "\n";
+		if (!message.endsWith("\n")) message += "\n";
 		errorScreen.insert(message, errorScreen.getDocument().getLength());
 	}
 
@@ -2424,7 +2442,9 @@ public class TextEditor extends JFrame implements ActionListener,
 		final CharArrayWriter writer = new CharArrayWriter();
 		PrintWriter out = new PrintWriter(writer);
 		e.printStackTrace(out);
-		for (Throwable cause = e.getCause(); cause != null; cause = cause.getCause()) {
+		for (Throwable cause = e.getCause(); cause != null; cause =
+			cause.getCause())
+		{
 			out.write("Caused by: ");
 			cause.printStackTrace(out);
 		}
@@ -2432,11 +2452,16 @@ public class TextEditor extends JFrame implements ActionListener,
 		textArea.append(writer.toString());
 	}
 
-	/** Removes invalid characters, shows a dialog.
-	 * @return The amount of invalid characters found. */
+	/**
+	 * Removes invalid characters, shows a dialog.
+	 * 
+	 * @return The amount of invalid characters found.
+	 */
 	public int zapGremlins() {
 		int count = getEditorPane().zapGremlins();
-		String msg = count > 0 ? "Zap Gremlins converted " + count + " invalid characters to spaces" : "No invalid characters found!";
+		String msg =
+			count > 0 ? "Zap Gremlins converted " + count +
+				" invalid characters to spaces" : "No invalid characters found!";
 		JOptionPane.showMessageDialog(this, msg);
 		return count;
 	}
@@ -2453,11 +2478,15 @@ public class TextEditor extends JFrame implements ActionListener,
 		return prefService.getInt(TAB_SIZE_PREFS, DEFAULT_TAB_SIZE);
 	}
 
-	private Reader evalScript(final String filename, Reader reader, final Writer output, final Writer errors) throws FileNotFoundException,
-			ModuleException {
+	private Reader evalScript(final String filename, Reader reader,
+		final Writer output, final Writer errors) throws FileNotFoundException,
+		ModuleException
+	{
 		final ScriptLanguage language = getCurrentLanguage();
 		if (respectAutoImports) {
-			reader = DefaultAutoImporters.prefixAutoImports(context, language, reader, errors);
+			reader =
+				DefaultAutoImporters.prefixAutoImports(context, language, reader,
+					errors);
 		}
 		// create script module for execution
 		final ScriptInfo info = new ScriptInfo(context, filename, reader);

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -256,7 +256,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		newFile.setMnemonic(KeyEvent.VK_N);
 		open = addToMenu(file, "Open...",  KeyEvent.VK_O, ctrl);
 		open.setMnemonic(KeyEvent.VK_O);
-		openRecent = new RecentFilesMenuItem(this);
+		openRecent = new RecentFilesMenuItem(prefService, this);
 		openRecent.setMnemonic(KeyEvent.VK_R);
 		file.add(openRecent);
 		save = addToMenu(file, "Save", KeyEvent.VK_S, ctrl);

--- a/src/main/java/net/imagej/ui/swing/script/TextEditorTab.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditorTab.java
@@ -1,0 +1,226 @@
+
+package net.imagej.ui.swing.script;
+
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.text.JTextComponent;
+
+import net.imagej.ui.swing.script.TextEditor.Executer;
+
+/**
+ * Tab in a {@link TextEditor} containing an {@link EditorPane}.
+ * 
+ * @author Jonathan Hale
+ */
+public class TextEditorTab extends JSplitPane {
+
+	protected final EditorPane editorPane;
+	protected final JTextArea screen = new JTextArea();
+	protected final JScrollPane scroll;
+	protected boolean showingErrors;
+	private Executer executer;
+	private final JButton runit, killit, toggleErrors;
+
+	private final TextEditor textEditor;
+
+	public TextEditorTab(final TextEditor textEditor) {
+		super(JSplitPane.VERTICAL_SPLIT);
+		super.setResizeWeight(350.0 / 430.0);
+
+		this.textEditor = textEditor;
+		editorPane = new EditorPane(textEditor);
+
+		screen.setEditable(false);
+		screen.setLineWrap(true);
+		screen.setFont(new Font("Courier", Font.PLAIN, 12));
+
+		final JPanel bottom = new JPanel();
+		bottom.setLayout(new GridBagLayout());
+		final GridBagConstraints bc = new GridBagConstraints();
+
+		bc.gridx = 0;
+		bc.gridy = 0;
+		bc.weightx = 0;
+		bc.weighty = 0;
+		bc.anchor = GridBagConstraints.NORTHWEST;
+		bc.fill = GridBagConstraints.NONE;
+		runit = new JButton("Run");
+		runit.addActionListener(new ActionListener() {
+
+			@Override
+			public void actionPerformed(final ActionEvent ae) {
+				textEditor.runText();
+			}
+		});
+		bottom.add(runit, bc);
+
+		bc.gridx = 1;
+		killit = new JButton("Kill");
+		killit.setEnabled(false);
+		killit.addActionListener(new ActionListener() {
+
+			@Override
+			public void actionPerformed(final ActionEvent ae) {
+				kill();
+			}
+		});
+		bottom.add(killit, bc);
+
+		bc.gridx = 2;
+		bc.fill = GridBagConstraints.HORIZONTAL;
+		bc.weightx = 1;
+		bottom.add(new JPanel(), bc);
+
+		bc.gridx = 3;
+		bc.fill = GridBagConstraints.NONE;
+		bc.weightx = 0;
+		bc.anchor = GridBagConstraints.NORTHEAST;
+		toggleErrors = new JButton("Show Errors");
+		toggleErrors.addActionListener(new ActionListener() {
+
+			@Override
+			public void actionPerformed(final ActionEvent e) {
+				toggleErrors();
+			}
+		});
+		bottom.add(toggleErrors, bc);
+
+		bc.gridx = 4;
+		bc.fill = GridBagConstraints.NONE;
+		bc.weightx = 0;
+		bc.anchor = GridBagConstraints.NORTHEAST;
+		final JButton clear = new JButton("Clear");
+		clear.addActionListener(new ActionListener() {
+
+			@Override
+			public void actionPerformed(final ActionEvent ae) {
+				getScreen().setText("");
+			}
+		});
+		bottom.add(clear, bc);
+
+		bc.gridx = 0;
+		bc.gridy = 1;
+		bc.anchor = GridBagConstraints.NORTHWEST;
+		bc.fill = GridBagConstraints.BOTH;
+		bc.weightx = 1;
+		bc.weighty = 1;
+		bc.gridwidth = 5;
+		screen.setEditable(false);
+		screen.setLineWrap(true);
+		final Font font = new Font("Courier", Font.PLAIN, 12);
+		screen.setFont(font);
+		scroll = new JScrollPane(screen);
+		scroll.setPreferredSize(new Dimension(600, 80));
+		bottom.add(scroll, bc);
+
+		super.setTopComponent(editorPane.wrappedInScrollbars());
+		super.setBottomComponent(bottom);
+	}
+
+	/** Invoke in the context of the event dispatch thread. */
+	public void prepare() {
+		editorPane.setEditable(false);
+		runit.setEnabled(false);
+		killit.setEnabled(true);
+	}
+
+	public void restore() {
+		SwingUtilities.invokeLater(new Runnable() {
+
+			@Override
+			public void run() {
+				editorPane.setEditable(true);
+				runit.setEnabled(true);
+				killit.setEnabled(false);
+				setExecutor(null);
+			}
+		});
+	}
+
+	public void toggleErrors() {
+		showingErrors = !showingErrors;
+		if (showingErrors) {
+			toggleErrors.setText("Show Output");
+			scroll.setViewportView(textEditor.errorScreen);
+		}
+		else {
+			toggleErrors.setText("Show Errors");
+			scroll.setViewportView(screen);
+		}
+	}
+
+	public void showErrors() {
+		if (!showingErrors) toggleErrors();
+		else if (scroll.getViewport().getView() == null) scroll
+			.setViewportView(textEditor.errorScreen);
+	}
+
+	public void showOutput() {
+		if (showingErrors) toggleErrors();
+	}
+
+	public JTextArea getScreen() {
+		return showingErrors ? textEditor.errorScreen : screen;
+	}
+
+	boolean isExecuting() {
+		return null != getExecuter();
+	}
+
+	public final String getTitle() {
+		return (editorPane.fileChanged() ? "*" : "") + editorPane.getFileName() +
+			(isExecuting() ? " (Running)" : "");
+	}
+
+	protected void kill() {
+		if (null == getExecuter()) return;
+		// Graceful attempt:
+		getExecuter().interrupt();
+		// Give it 3 seconds. Then, stop it.
+		final long now = System.currentTimeMillis();
+		new Thread() {
+
+			{
+				setPriority(Thread.NORM_PRIORITY);
+			}
+
+			@Override
+			public void run() {
+				while (System.currentTimeMillis() - now < 3000)
+					try {
+						Thread.sleep(100);
+					}
+					catch (final InterruptedException e) {
+						/* ignore */
+					}
+				if (null != getExecuter()) getExecuter().obliterate();
+				restore();
+
+			}
+		}.start();
+	}
+
+	public Executer getExecuter() {
+		return executer;
+	}
+
+	public void setExecutor(Executer executer) {
+		this.executer = executer;
+	}
+
+	public JTextComponent getEditorPane() {
+		return editorPane;
+	}
+}

--- a/src/main/java/net/imagej/ui/swing/script/TextEditorTab.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditorTab.java
@@ -39,7 +39,7 @@ public class TextEditorTab extends JSplitPane {
 		super.setResizeWeight(350.0 / 430.0);
 
 		this.textEditor = textEditor;
-		editorPane = new EditorPane(textEditor);
+		editorPane = new EditorPane();
 
 		screen.setEditable(false);
 		screen.setLineWrap(true);

--- a/src/main/java/net/imagej/ui/swing/script/highliters/BeanshellHighlighter.java
+++ b/src/main/java/net/imagej/ui/swing/script/highliters/BeanshellHighlighter.java
@@ -1,0 +1,20 @@
+
+package net.imagej.ui.swing.script.highliters;
+
+import net.imagej.ui.swing.script.SyntaxHighlighter;
+
+import org.fife.ui.rsyntaxtextarea.modes.JavaTokenMaker;
+import org.scijava.plugin.Plugin;
+
+/**
+ * SyntaxHighliter for "beanshell".
+ * 
+ * @author Johannes Schindelin
+ * @author Jonathan Hale
+ */
+@Plugin(type = SyntaxHighlighter.class, label = "beanshell")
+public class BeanshellHighlighter extends JavaTokenMaker implements
+	SyntaxHighlighter
+{
+	// Everything implemented in JavaTokenMaker
+}

--- a/src/main/java/net/imagej/ui/swing/script/highliters/ECMAScriptHighlighter.java
+++ b/src/main/java/net/imagej/ui/swing/script/highliters/ECMAScriptHighlighter.java
@@ -1,0 +1,20 @@
+
+package net.imagej.ui.swing.script.highliters;
+
+import net.imagej.ui.swing.script.SyntaxHighlighter;
+
+import org.fife.ui.rsyntaxtextarea.modes.JavaScriptTokenMaker;
+import org.scijava.plugin.Plugin;
+
+/**
+ * SyntaxHighliter for "ecmascript".
+ * 
+ * @author Johannes Schindelin
+ * @author Jonathan Hale
+ */
+@Plugin(type = SyntaxHighlighter.class, label = "ecmascript")
+public class ECMAScriptHighlighter extends JavaScriptTokenMaker implements
+	SyntaxHighlighter
+{
+	// Everything implemented in JavaScriptTokenMaker
+}

--- a/src/main/java/net/imagej/ui/swing/script/highliters/IJ1MacroHighlighter.java
+++ b/src/main/java/net/imagej/ui/swing/script/highliters/IJ1MacroHighlighter.java
@@ -1,7 +1,6 @@
 
 package net.imagej.ui.swing.script.highliters;
 
-import net.imagej.ui.swing.script.ImageJMacroTokenMaker;
 import net.imagej.ui.swing.script.SyntaxHighlighter;
 
 import org.scijava.plugin.Plugin;

--- a/src/main/java/net/imagej/ui/swing/script/highliters/IJ1MacroHighlighter.java
+++ b/src/main/java/net/imagej/ui/swing/script/highliters/IJ1MacroHighlighter.java
@@ -1,0 +1,20 @@
+
+package net.imagej.ui.swing.script.highliters;
+
+import net.imagej.ui.swing.script.ImageJMacroTokenMaker;
+import net.imagej.ui.swing.script.SyntaxHighlighter;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * SyntaxHighliter for ij1-macros.
+ * 
+ * @author Johannes Schindelin
+ * @author Jonathan Hale
+ */
+@Plugin(type = SyntaxHighlighter.class, label = "ij1-macro")
+public class IJ1MacroHighlighter extends ImageJMacroTokenMaker implements
+	SyntaxHighlighter
+{
+	// Everything implemented in ImageJMacroTokenMaker
+}

--- a/src/main/java/net/imagej/ui/swing/script/highliters/ImageJMacroTokenMaker.java
+++ b/src/main/java/net/imagej/ui/swing/script/highliters/ImageJMacroTokenMaker.java
@@ -29,7 +29,7 @@
  * #L%
  */
 
-package net.imagej.ui.swing.script;
+package net.imagej.ui.swing.script.highliters;
 
 import java.io.IOException;
 

--- a/src/main/java/net/imagej/ui/swing/script/highliters/MatlabHighlighter.java
+++ b/src/main/java/net/imagej/ui/swing/script/highliters/MatlabHighlighter.java
@@ -1,7 +1,6 @@
 
 package net.imagej.ui.swing.script.highliters;
 
-import net.imagej.ui.swing.script.MatlabTokenMaker;
 import net.imagej.ui.swing.script.SyntaxHighlighter;
 
 import org.scijava.plugin.Plugin;

--- a/src/main/java/net/imagej/ui/swing/script/highliters/MatlabHighlighter.java
+++ b/src/main/java/net/imagej/ui/swing/script/highliters/MatlabHighlighter.java
@@ -1,0 +1,20 @@
+
+package net.imagej.ui.swing.script.highliters;
+
+import net.imagej.ui.swing.script.MatlabTokenMaker;
+import net.imagej.ui.swing.script.SyntaxHighlighter;
+
+import org.scijava.plugin.Plugin;
+
+/**
+ * SyntaxHighliter for matlab scripts.
+ * 
+ * @author Johannes Schindelin
+ * @author Jonathan Hale
+ */
+@Plugin(type = SyntaxHighlighter.class, label = "matlab")
+public class MatlabHighlighter extends MatlabTokenMaker implements
+	SyntaxHighlighter
+{
+	// Everything implemented in MatlabTokenMaker
+}

--- a/src/main/java/net/imagej/ui/swing/script/highliters/MatlabTokenMaker.java
+++ b/src/main/java/net/imagej/ui/swing/script/highliters/MatlabTokenMaker.java
@@ -29,7 +29,7 @@
  * #L%
  */
 
-package net.imagej.ui.swing.script;
+package net.imagej.ui.swing.script.highliters;
 
 import java.io.IOException;
 


### PR DESCRIPTION
Hello everybody, 

as part of #40, I cleaned up the existing script editor code, extracted some classes for readability and added a bunch of javadoc. This involved code formatting, which I tried to keep in separate commits. Everything is done in small and (hopefully) clear steps.

In general this is all refactoring and should not result in any visible changes for the user, but does break the API every now and then (changing member access to private and providing a getter for example).

Greetings, 
Squareys