### PR TITLE
Scripteditor codeassist and code completion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,16 @@
 			<version>2.5.7</version>
 		</dependency>
 		<dependency>
+			<groupId>com.fifesoft</groupId>
+			<artifactId>autocomplete</artifactId>
+			<version>2.5.7</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fifesoft</groupId>
+			<artifactId>languagesupport</artifactId>
+			<version>2.5.7</version>
+		</dependency>
+		<dependency>
 			<groupId>com.miglayout</groupId>
 			<artifactId>miglayout</artifactId>
 			<classifier>swing</classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
 			<url>http://maven.imagej.net/content/groups/public</url>
 		</repository>
 	</repositories>
+	
+	<properties>
+		<fifesoft.version>2.5.7</fifesoft.version>
+	</properties>
 
 	<dependencies>
 		<!-- ImageJ dependencies -->
@@ -84,17 +88,17 @@
 		<dependency>
 			<groupId>com.fifesoft</groupId>
 			<artifactId>rsyntaxtextarea</artifactId>
-			<version>2.5.7</version>
+			<version>${fifesoft.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fifesoft</groupId>
 			<artifactId>autocomplete</artifactId>
-			<version>2.5.7</version>
+			<version>${fifesoft.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fifesoft</groupId>
 			<artifactId>languagesupport</artifactId>
-			<version>2.5.7</version>
+			<version>${fifesoft.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.miglayout</groupId>

--- a/src/main/java/net/imagej/ui/swing/script/EditorPane.java
+++ b/src/main/java/net/imagej/ui/swing/script/EditorPane.java
@@ -449,7 +449,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	{
 		// uninstall existing language support.
 		LanguageSupport support =
-			languageSupportService.getCompletionProvider(currentLanguage);
+			languageSupportService.getLanguageSupport(currentLanguage);
 		if (support != null) {
 			support.uninstall(this);
 		}
@@ -495,7 +495,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		}
 
 		// try to get language support for current language, may be null.
-		support = languageSupportService.getCompletionProvider(currentLanguage);
+		support = languageSupportService.getLanguageSupport(currentLanguage);
 
 		if (support != null) {
 			support.install(this);

--- a/src/main/java/net/imagej/ui/swing/script/LanguageSupportPlugin.java
+++ b/src/main/java/net/imagej/ui/swing/script/LanguageSupportPlugin.java
@@ -1,0 +1,17 @@
+
+package net.imagej.ui.swing.script;
+
+import org.fife.rsta.ac.LanguageSupport;
+import org.fife.ui.autocomplete.AutoCompletion;
+import org.scijava.plugin.SingletonPlugin;
+
+/**
+ * Interface for {@link AutoCompletion} plugins.
+ * 
+ * @author Jonathan Hale
+ */
+public interface LanguageSupportPlugin extends SingletonPlugin,
+	LanguageSupport
+{
+	// NB: Marker interface.
+}

--- a/src/main/java/net/imagej/ui/swing/script/LanguageSupportPlugin.java
+++ b/src/main/java/net/imagej/ui/swing/script/LanguageSupportPlugin.java
@@ -13,5 +13,9 @@ import org.scijava.plugin.SingletonPlugin;
 public interface LanguageSupportPlugin extends SingletonPlugin,
 	LanguageSupport
 {
-	// NB: Marker interface.
+
+	/**
+	 * @return the name of the language this plugin adds support for.
+	 */
+	public String getLanguageName();
 }

--- a/src/main/java/net/imagej/ui/swing/script/LanguageSupportService.java
+++ b/src/main/java/net/imagej/ui/swing/script/LanguageSupportService.java
@@ -1,0 +1,52 @@
+
+package net.imagej.ui.swing.script;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.fife.rsta.ac.LanguageSupport;
+import org.scijava.plugin.AbstractSingletonService;
+import org.scijava.plugin.Plugin;
+import org.scijava.plugin.PluginInfo;
+import org.scijava.script.ScriptLanguage;
+import org.scijava.service.Service;
+
+/**
+ * Service which manages {@link LanguageSupportPlugin}s.
+ * 
+ * @author Jonathan Hale
+ */
+@Plugin(type = Service.class)
+public class LanguageSupportService extends
+	AbstractSingletonService<LanguageSupportPlugin>
+{
+
+	final Map<String, LanguageSupportPlugin> languageSupportMap =
+		new HashMap<String, LanguageSupportPlugin>();
+
+	@Override
+	public Class<LanguageSupportPlugin> getPluginType() {
+		return LanguageSupportPlugin.class;
+	}
+
+	@Override
+	public void initialize() {
+		super.initialize();
+
+		for (PluginInfo<LanguageSupportPlugin> p : this.getPlugins()) {
+			languageSupportMap.put(p.getLabel().toLowerCase(), this.getInstance(p.getPluginClass()));
+		}
+	}
+
+	/**
+	 * Get a {@link LanguageSupport} for the given language.
+	 * 
+	 * @param language
+	 * @return a {@link LanguageSupport} matching the given language or the
+	 *         <code>null</code> if there was none.
+	 */
+	public LanguageSupport getCompletionProvider(ScriptLanguage language) {
+		return languageSupportMap.get(language.getLanguageName().toLowerCase());
+	}
+
+}

--- a/src/main/java/net/imagej/ui/swing/script/LanguageSupportService.java
+++ b/src/main/java/net/imagej/ui/swing/script/LanguageSupportService.java
@@ -34,7 +34,9 @@ public class LanguageSupportService extends
 		super.initialize();
 
 		for (PluginInfo<LanguageSupportPlugin> p : this.getPlugins()) {
-			languageSupportMap.put(p.getLabel().toLowerCase(), this.getInstance(p.getPluginClass()));
+			final String name = p.getName().toLowerCase();
+			LanguageSupportPlugin instance = this.getInstance(p.getPluginClass());
+			languageSupportMap.put(name, instance);
 		}
 	}
 

--- a/src/main/java/net/imagej/ui/swing/script/LanguageSupportService.java
+++ b/src/main/java/net/imagej/ui/swing/script/LanguageSupportService.java
@@ -48,7 +48,7 @@ public class LanguageSupportService extends
 	 *         <code>null</code> if there was none or language was
 	 *         <code>null</code>.
 	 */
-	public LanguageSupport getCompletionProvider(ScriptLanguage language) {
+	public LanguageSupport getLanguageSupport(ScriptLanguage language) {
 		if (language == null) {
 			return null;
 		}

--- a/src/main/java/net/imagej/ui/swing/script/LanguageSupportService.java
+++ b/src/main/java/net/imagej/ui/swing/script/LanguageSupportService.java
@@ -43,10 +43,15 @@ public class LanguageSupportService extends
 	 * 
 	 * @param language
 	 * @return a {@link LanguageSupport} matching the given language or the
-	 *         <code>null</code> if there was none.
+	 *         <code>null</code> if there was none or language was
+	 *         <code>null</code>.
 	 */
 	public LanguageSupport getCompletionProvider(ScriptLanguage language) {
-		return languageSupportMap.get(language.getLanguageName().toLowerCase());
+		if (language == null) {
+			return null;
+		}
+		final String name = language.getLanguageName().toLowerCase();
+		return languageSupportMap.get(name);
 	}
 
 }

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -227,7 +227,7 @@ public class TextEditor extends JFrame implements ActionListener,
 	public TextEditor(final Context context) {
 		super("Script Editor");
 		context.inject(this);
-		initializeTokenMakers(pluginService, log);
+		initializeTokenMakers();
 		loadPreferences();
 
 		// Initialize menu
@@ -647,9 +647,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		editorPane.requestFocus();
 	}
 
-	private synchronized static void initializeTokenMakers(
-		final PluginService pluginService, final LogService log)
-	{
+	private synchronized void initializeTokenMakers() {
 		if (tokenMakerFactory != null) return;
 		tokenMakerFactory =
 			(AbstractTokenMakerFactory) TokenMakerFactory.getDefaultInstance();

--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -654,11 +654,11 @@ public class TextEditor extends JFrame implements ActionListener,
 		for (final PluginInfo<SyntaxHighlighter> info : pluginService
 			.getPluginsOfType(SyntaxHighlighter.class))
 			try {
-				tokenMakerFactory.putMapping("text/" + info.getLabel(), info
+				tokenMakerFactory.putMapping("text/" + info.getName(), info
 					.getClassName());
 			}
 			catch (final Throwable t) {
-				log.warn("Could not register " + info.getLabel(), t);
+				log.warn("Could not register " + info.getName(), t);
 			}
 	}
 

--- a/src/main/java/net/imagej/ui/swing/script/highliters/BeanshellHighlighter.java
+++ b/src/main/java/net/imagej/ui/swing/script/highliters/BeanshellHighlighter.java
@@ -12,7 +12,7 @@ import org.scijava.plugin.Plugin;
  * @author Johannes Schindelin
  * @author Jonathan Hale
  */
-@Plugin(type = SyntaxHighlighter.class, label = "beanshell")
+@Plugin(type = SyntaxHighlighter.class, name = "beanshell")
 public class BeanshellHighlighter extends JavaTokenMaker implements
 	SyntaxHighlighter
 {

--- a/src/main/java/net/imagej/ui/swing/script/highliters/ECMAScriptHighlighter.java
+++ b/src/main/java/net/imagej/ui/swing/script/highliters/ECMAScriptHighlighter.java
@@ -12,7 +12,7 @@ import org.scijava.plugin.Plugin;
  * @author Johannes Schindelin
  * @author Jonathan Hale
  */
-@Plugin(type = SyntaxHighlighter.class, label = "ecmascript")
+@Plugin(type = SyntaxHighlighter.class, name = "ecmascript")
 public class ECMAScriptHighlighter extends JavaScriptTokenMaker implements
 	SyntaxHighlighter
 {

--- a/src/main/java/net/imagej/ui/swing/script/highliters/IJ1MacroHighlighter.java
+++ b/src/main/java/net/imagej/ui/swing/script/highliters/IJ1MacroHighlighter.java
@@ -11,7 +11,7 @@ import org.scijava.plugin.Plugin;
  * @author Johannes Schindelin
  * @author Jonathan Hale
  */
-@Plugin(type = SyntaxHighlighter.class, label = "ij1-macro")
+@Plugin(type = SyntaxHighlighter.class, name = "ij1-macro")
 public class IJ1MacroHighlighter extends ImageJMacroTokenMaker implements
 	SyntaxHighlighter
 {

--- a/src/main/java/net/imagej/ui/swing/script/highliters/MatlabHighlighter.java
+++ b/src/main/java/net/imagej/ui/swing/script/highliters/MatlabHighlighter.java
@@ -11,7 +11,7 @@ import org.scijava.plugin.Plugin;
  * @author Johannes Schindelin
  * @author Jonathan Hale
  */
-@Plugin(type = SyntaxHighlighter.class, label = "matlab")
+@Plugin(type = SyntaxHighlighter.class, name = "matlab")
 public class MatlabHighlighter extends MatlabTokenMaker implements
 	SyntaxHighlighter
 {

--- a/src/main/java/net/imagej/ui/swing/script/languagesupport/JavaLanguageSupportPlugin.java
+++ b/src/main/java/net/imagej/ui/swing/script/languagesupport/JavaLanguageSupportPlugin.java
@@ -1,0 +1,29 @@
+
+package net.imagej.ui.swing.script.languagesupport;
+
+import java.io.IOException;
+
+import net.imagej.ui.swing.script.LanguageSupportPlugin;
+import net.imagej.ui.swing.script.LanguageSupportService;
+
+import org.fife.rsta.ac.java.JavaLanguageSupport;
+import org.scijava.plugin.Plugin;
+
+/**
+ * {@link LanguageSupportPlugin} for the java language.
+ * 
+ * @author Jonathan Hale
+ * @see JavaLanguageSupport
+ * @see LanguageSupportService
+ */
+@Plugin(type = LanguageSupportPlugin.class, label = "java")
+public class JavaLanguageSupportPlugin extends JavaLanguageSupport
+	implements LanguageSupportPlugin
+{
+
+	public JavaLanguageSupportPlugin() throws IOException {
+		super();
+		
+		getJarManager().addCurrentJreClassFileSource();
+	}
+}

--- a/src/main/java/net/imagej/ui/swing/script/languagesupport/JavaLanguageSupportPlugin.java
+++ b/src/main/java/net/imagej/ui/swing/script/languagesupport/JavaLanguageSupportPlugin.java
@@ -16,7 +16,7 @@ import org.scijava.plugin.Plugin;
  * @see JavaLanguageSupport
  * @see LanguageSupportService
  */
-@Plugin(type = LanguageSupportPlugin.class, label = "java")
+@Plugin(type = LanguageSupportPlugin.class, name = "java")
 public class JavaLanguageSupportPlugin extends JavaLanguageSupport
 	implements LanguageSupportPlugin
 {

--- a/src/main/java/net/imagej/ui/swing/script/languagesupport/JavaLanguageSupportPlugin.java
+++ b/src/main/java/net/imagej/ui/swing/script/languagesupport/JavaLanguageSupportPlugin.java
@@ -3,11 +3,11 @@ package net.imagej.ui.swing.script.languagesupport;
 
 import java.io.IOException;
 
-import net.imagej.ui.swing.script.LanguageSupportPlugin;
-import net.imagej.ui.swing.script.LanguageSupportService;
-
 import org.fife.rsta.ac.java.JavaLanguageSupport;
 import org.scijava.plugin.Plugin;
+
+import net.imagej.ui.swing.script.LanguageSupportPlugin;
+import net.imagej.ui.swing.script.LanguageSupportService;
 
 /**
  * {@link LanguageSupportPlugin} for the java language.
@@ -16,14 +16,20 @@ import org.scijava.plugin.Plugin;
  * @see JavaLanguageSupport
  * @see LanguageSupportService
  */
-@Plugin(type = LanguageSupportPlugin.class, name = "java")
-public class JavaLanguageSupportPlugin extends JavaLanguageSupport
-	implements LanguageSupportPlugin
+@Plugin(type = LanguageSupportPlugin.class)
+public class JavaLanguageSupportPlugin extends JavaLanguageSupport implements
+	LanguageSupportPlugin
 {
 
 	public JavaLanguageSupportPlugin() throws IOException {
 		super();
-		
+
 		getJarManager().addCurrentJreClassFileSource();
 	}
+
+	@Override
+	public String getLanguageName() {
+		return "java";
+	}
+
 }

--- a/src/main/java/net/imagej/ui/swing/script/languagesupport/JavaScriptLanguageSupportPlugin.java
+++ b/src/main/java/net/imagej/ui/swing/script/languagesupport/JavaScriptLanguageSupportPlugin.java
@@ -14,7 +14,7 @@ import org.scijava.plugin.Plugin;
  * @see JavaScriptLanguageSupport
  * @see LanguageSupportService
  */
-@Plugin(type = LanguageSupportPlugin.class, label = "javascript")
+@Plugin(type = LanguageSupportPlugin.class, name = "javascript")
 public class JavaScriptLanguageSupportPlugin extends JavaScriptLanguageSupport
 	implements LanguageSupportPlugin
 {

--- a/src/main/java/net/imagej/ui/swing/script/languagesupport/JavaScriptLanguageSupportPlugin.java
+++ b/src/main/java/net/imagej/ui/swing/script/languagesupport/JavaScriptLanguageSupportPlugin.java
@@ -1,11 +1,11 @@
 
 package net.imagej.ui.swing.script.languagesupport;
 
-import net.imagej.ui.swing.script.LanguageSupportPlugin;
-import net.imagej.ui.swing.script.LanguageSupportService;
-
 import org.fife.rsta.ac.js.JavaScriptLanguageSupport;
 import org.scijava.plugin.Plugin;
+
+import net.imagej.ui.swing.script.LanguageSupportPlugin;
+import net.imagej.ui.swing.script.LanguageSupportService;
 
 /**
  * {@link LanguageSupportPlugin} for the javascript language.
@@ -14,12 +14,17 @@ import org.scijava.plugin.Plugin;
  * @see JavaScriptLanguageSupport
  * @see LanguageSupportService
  */
-@Plugin(type = LanguageSupportPlugin.class, name = "javascript")
+@Plugin(type = LanguageSupportPlugin.class)
 public class JavaScriptLanguageSupportPlugin extends JavaScriptLanguageSupport
 	implements LanguageSupportPlugin
 {
 
 	public JavaScriptLanguageSupportPlugin() {
 		super();
+	}
+
+	@Override
+	public String getLanguageName() {
+		return "javascript";
 	}
 }

--- a/src/main/java/net/imagej/ui/swing/script/languagesupport/JavaScriptLanguageSupportPlugin.java
+++ b/src/main/java/net/imagej/ui/swing/script/languagesupport/JavaScriptLanguageSupportPlugin.java
@@ -1,0 +1,25 @@
+
+package net.imagej.ui.swing.script.languagesupport;
+
+import net.imagej.ui.swing.script.LanguageSupportPlugin;
+import net.imagej.ui.swing.script.LanguageSupportService;
+
+import org.fife.rsta.ac.js.JavaScriptLanguageSupport;
+import org.scijava.plugin.Plugin;
+
+/**
+ * {@link LanguageSupportPlugin} for the javascript language.
+ * 
+ * @author Jonathan Hale
+ * @see JavaScriptLanguageSupport
+ * @see LanguageSupportService
+ */
+@Plugin(type = LanguageSupportPlugin.class, label = "javascript")
+public class JavaScriptLanguageSupportPlugin extends JavaScriptLanguageSupport
+	implements LanguageSupportPlugin
+{
+
+	public JavaScriptLanguageSupportPlugin() {
+		super();
+	}
+}


### PR DESCRIPTION
Hello everybody!

This adds codecompletion/-assist to the script editor using fifesoft `Autocomplete` and `RSTALanguageSupport`. This branch is based on #51, which is needed to be merged first.

Support for Autocompletion can be extend by extending the `LanguageSupportPlugin`. The repository `RSTALanguageSupport` also implements outline trees for java for example, which one could take into consideration for the script editor. (Not implemented in this PR!)

For this pullrequest, code assist is implemented for Java and JavaScript.

Have a nice day, 
Squareys.