### PR TITLE
TextEditor: add space in checkForOutsideChanges()

### DIFF
--- a/src/main/java/net/imagej/ui/swing/script/TextEditor.java
+++ b/src/main/java/net/imagej/ui/swing/script/TextEditor.java
@@ -679,7 +679,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		final EditorPane editorPane = getEditorPane();
 		if (editorPane.wasChangedOutside()) {
 			reload("The file " + editorPane.getFile().getName() +
-				"was changed outside of the editor");
+				" was changed outside of the editor");
 		}
 
 	}


### PR DESCRIPTION
Changes "The file **XYZ.pywas** changed outside of the editor" message to "The file **XYZ.py was** changed outside of the editor".