### PR TITLE
Bugfixing user interface of Update Site List

### DIFF
--- a/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
+++ b/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
@@ -282,6 +282,14 @@ public class SitesDialog extends JDialog implements ActionListener {
 
 	private void addNew() {
 		add(new UpdateSite(makeUniqueSiteName("New"), "", "", "", null, null, 0l));
+
+		table.changeSelection( table.getRowCount()-1, 2, false, false);
+
+		if (table.editCellAt(table.getRowCount()-1, 2))
+		{
+			Component editor = table.getEditorComponent();
+			editor.requestFocusInWindow();
+		}
 	}
 
 	private final static String PERSONAL_SITES_URL = "http://sites.imagej.net/";

--- a/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
+++ b/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
@@ -468,6 +468,7 @@ public class SitesDialog extends JDialog implements ActionListener {
 
 	@Override
 	public void dispose() {
+		table.editCellAt(0,0);
 		super.dispose();
 		updaterFrame.updateFilesTable();
 		updaterFrame.enableApplyOrUpload();


### PR DESCRIPTION
Hey guys,

some users had issues with entering updates sites to ImageJ/Fiji. So I changed two things:
* After clicking "Add update site" button, the new line in the table was not shown. The user had to scroll down on his own. Now, after the fix: The new line is shown and the cursor is set to the URL field. The user can just start typing.
* After entering the URL and immediately clicking the "Close" button, the URL was not saved. The user had to click somewhere else before to close the "editor". Now, after the fix, the URL is saved before the window disappears.

Cheers,
Robert
