### PR TITLE
OverlayManager: fix duplicated Context parameter

### DIFF
--- a/src/main/java/net/imagej/ui/swing/commands/OverlayManager.java
+++ b/src/main/java/net/imagej/ui/swing/commands/OverlayManager.java
@@ -33,11 +33,9 @@ package net.imagej.ui.swing.commands;
 
 import net.imagej.ui.swing.overlay.SwingOverlayManager;
 
-import org.scijava.Context;
 import org.scijava.command.Command;
 import org.scijava.command.ContextCommand;
 import org.scijava.plugin.Menu;
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -49,12 +47,9 @@ import org.scijava.plugin.Plugin;
 	@Menu(label = "Overlay Manager") })
 public class OverlayManager extends ContextCommand {
 
-	@Parameter
-	private Context context;
-
 	@Override
 	public void run() {
-		final SwingOverlayManager overlaymgr = new SwingOverlayManager(context);
+		final SwingOverlayManager overlaymgr = new SwingOverlayManager(getContext());
 		overlaymgr.setVisible(true);
 	}
 


### PR DESCRIPTION
Since `OverlayManager` extends `ContextCommand` (which in turn extends `AbstractContextual`) a `Context` parameter is already defined and injected.

In practice, this leads to an issue when starting the Overlay Manager as described on the ImageJ mailing list (http://imagej.1557.x6.nabble.com/Status-of-the-fiji-Overlay-Manager-td5019460.html).