### PR TITLE
Deprecate net.imagej.ui.swing.viewer.table.*

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>17.1.1</version>
+		<version>23.2.0</version>
 		<relativePath />
 	</parent>
 
@@ -125,6 +125,9 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>
+
+		<!-- NB: Define scijava-ui-swing version until pom-scijava 24.0.0 is released -->
+		<scijava-ui-swing.version>0.12.0</scijava-ui-swing.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/net/imagej/ui/swing/viewer/table/SwingTableDisplayPanel.java
+++ b/src/main/java/net/imagej/ui/swing/viewer/table/SwingTableDisplayPanel.java
@@ -46,7 +46,10 @@ import org.scijava.ui.viewer.DisplayWindow;
  * 
  * @author Curtis Rueden
  * @author Barry DeZonia
+ * 
+ * @deprecated replaced by {@link org.scijava.ui.swing.viewer.table.SwingTableDisplayPanel}
  */
+@Deprecated
 public class SwingTableDisplayPanel extends JScrollPane implements
 	TableDisplayPanel
 {

--- a/src/main/java/net/imagej/ui/swing/viewer/table/SwingTableDisplayViewer.java
+++ b/src/main/java/net/imagej/ui/swing/viewer/table/SwingTableDisplayViewer.java
@@ -48,7 +48,10 @@ import org.scijava.ui.viewer.DisplayWindow;
  * {@link JTable}.
  * 
  * @author Curtis Rueden
+ * 
+ * @deprecated replaced by {@link org.scijava.ui.swing.viewer.table.SwingTableDisplayViewer}
  */
+@Deprecated
 @Plugin(type = DisplayViewer.class)
 public class SwingTableDisplayViewer extends AbstractTableDisplayViewer {
 


### PR DESCRIPTION
The display classes for tables moved to `scijava-ui-swing` with the introduction of the `scijava-table` component.

This needs to wait until https://github.com/scijava/scijava-ui-swing/pull/42 is merged and released.