### PR TITLE
Updater V1: UI for update site URL changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>27.0.1</version>
 		<relativePath />
 	</parent>
 
@@ -126,8 +126,6 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 
-		<!-- NB: Define scijava-ui-swing version until pom-scijava 24.0.0 is released -->
-		<scijava-ui-swing.version>0.12.0</scijava-ui-swing.version>
 		<imagej-updater.version>0.10.1</imagej-updater.version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,18 @@
 				<role>maintainer</role>
 			</roles>
 		</developer>
+		<developer>
+			<id>frauzufall</id>
+			<name>Deborah Schmidt</name>
+			<url>https://imagej.net/User:Frauzufall</url>
+			<roles>
+				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
+			</roles>
+		</developer>
 	</developers>
 	<contributors>
 		<contributor>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 
 		<!-- NB: Define scijava-ui-swing version until pom-scijava 24.0.0 is released -->
 		<scijava-ui-swing.version>0.12.0</scijava-ui-swing.version>
+		<imagej-updater.version>0.10.1</imagej-updater.version>
 	</properties>
 
 	<repositories>
@@ -198,5 +199,11 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 			<artifactId>imagej-ui-awt</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/net/imagej/ui/swing/updater/ReviewSiteURLsDialog.java
+++ b/src/main/java/net/imagej/ui/swing/updater/ReviewSiteURLsDialog.java
@@ -1,0 +1,482 @@
+package net.imagej.ui.swing.updater;
+
+import net.imagej.updater.URLChange;
+import net.imagej.updater.UpdateSite;
+import net.imagej.updater.util.HTTPSUtil;
+import net.miginfocom.swing.MigLayout;
+
+import javax.swing.*;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellEditor;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableColumnModel;
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.HTMLEditorKit;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+
+import static net.imagej.ui.swing.updater.SitesDialog.escapeCancels;
+
+/**
+ * The dialog in which updated URLs of available update sites will be shown
+ * and the user can chose to accept these updates.
+ *
+ * @author Deborah Schmidt
+ */
+public class ReviewSiteURLsDialog extends JDialog implements ActionListener {
+
+	List< URLChange > urlChanges;
+
+	private UpdatableTableDataModel tableModel;
+	private JTable table;
+	JButton cancel, submit, ok;
+	JRadioButton updateAll;
+	JRadioButton keepAll;
+	JRadioButton manualChoice;
+	JCheckBox stopAsking;
+	private ButtonGroup generalChoiceGroup = new ButtonGroup();
+	private final static int nameCol = 0, urlCol = 1;
+	private final static String appendOld = " (keep URL)", appendNew = " (update URL)";
+	private boolean okPressed;
+
+	/**
+	 * @param owner The frame that this dialog will be placed relative to
+	 * @param urlChanges The urlChanges
+	 */
+	public ReviewSiteURLsDialog(final UpdaterFrame owner, final List< URLChange > urlChanges)
+	{
+		super(owner, "Changes to available update sites", ModalityType.DOCUMENT_MODAL);
+
+		this.urlChanges = urlChanges;
+
+		final Container contentPane = getContentPane();
+		contentPane.setLayout(new MigLayout("fill, gap 0"));
+
+		this.urlChanges.forEach( change -> change.setApproved(change.isRecommended()));
+
+		if( this.urlChanges.size() > 0) {
+			setMinimumSize(new Dimension(900, 0));
+			contentPane.add(createHeader(), "span, grow");
+			contentPane.add(createUpdateSiteScrollPane(), "newline, span, grow, push");
+			contentPane.add(createButtonsPanel(), "dock south");
+			updateGeneralChoices();
+		} else {
+			setMinimumSize(new Dimension(0, 0));
+			contentPane.add(createOkPanel(), "dock south");
+			contentPane.add(createOkIcon(), "w 70px!");
+			contentPane.add(createEverythingIsFineMessage());
+		}
+
+		escapeCancels(this);
+		setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+		pack();
+		setLocationRelativeTo(owner);
+	}
+
+	static boolean shouldBeDisplayed(final List<URLChange> changes ) {
+		for(URLChange change : changes) {
+			if(change.isRecommended() && !change.isApproved()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	boolean isOkPressed() {
+		return okPressed;
+	}
+
+	private Component createEverythingIsFineMessage() {
+		JEditorPane text = createHTMLText("<html><h2>Software package sources up to date</h2>" +
+				"No updated URLs found for activated update sites.</html>");
+		text.setBorder(BorderFactory.createEmptyBorder(10, 10, 20, 25));
+		text.setMinimumSize(new Dimension(0,0));
+		return text;
+	}
+
+	private Component createOkPanel() {
+		JPanel panel = new JPanel();
+		ok = new JButton("OK");
+		panel.setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, Color.darkGray));
+		panel.add(ok);
+		ok.addActionListener(this);
+		getRootPane().setDefaultButton(ok);
+		return panel;
+	}
+
+	private Component createHeader() {
+		JPanel panel = new JPanel();
+		panel.setLayout(new MigLayout("fillx, ins 5px", "[][]push[]"));
+		panel.add(createUpdatesAvailableMessage(), "span, wrap, wmax 600px");
+		panel.add(createAttentionIcon(), "w 100px!");
+		panel.add(createGeneralChoices(), "wrap, w 300px!, bottom, left");
+		if(HTTPSUtil.supportsHTTPS()) {
+			panel.add(createHTTPSInfo(), "wmax 250px, dock east");
+		}
+		return panel;
+	}
+
+	private static Component createAttentionIcon() {
+//		JLabel label = new JLabel("?", SwingConstants.CENTER);
+//		label.setFont(new Font(label.getFont().getName(), Font.BOLD, 84));
+//		label.setForeground(new Color(220,220,220));
+		return new JLabel(javax.swing.UIManager.getIcon("OptionPane.warningIcon"));
+	}
+
+	private static Component createOkIcon() {
+		JLabel label = new JLabel(":-)", SwingConstants.CENTER);
+		label.setFont(new Font(label.getFont().getName(), Font.BOLD, 32));
+		label.setForeground(new Color(114, 200, 218));
+		return label;
+//		return new JLabel(javax.swing.UIManager.getIcon("OptionPane.informationIcon"));
+	}
+
+	private static Component createUpdatesAvailableMessage() {
+		return createHTMLText("<html><h2>Updated software package sources</h2>" +
+				"<p>Please review the following update site URL changes.<br/>" +
+				"If you have never heard of update sites," +
+				" just click <b>OK</b> at the bottom.</p></html>");
+	}
+
+	private static Component createHTTPSInfo() {
+		// TODO remove note in Updater V2
+		JEditorPane text = createHTMLText("<html><h3>ImageJ is improving<br/>data security!</h3>" +
+				"From now on ImageJ is supposed to update more securely via HTTPS. " +
+				"Therefore addresses of update sites currently in use by your ImageJ installation " +
+				"need to be updated.</html>");
+		text.setBackground(new Color(250,250,250));
+		text.setBorder(BorderFactory.createEmptyBorder(25,15,25,25));
+		String bodyRule = "body { color: #404042; }";
+		((HTMLDocument)text.getDocument()).getStyleSheet().addRule(bodyRule);
+		text.setOpaque(true);
+		return text;
+	}
+
+	private static JEditorPane createHTMLText(String text) {
+		JEditorPane component =
+				new JEditorPane(new HTMLEditorKit().getContentType(), text);
+		component.setEditable(false);
+		component.setOpaque(false);
+		Font font = UIManager.getFont("Label.font");
+		String bodyRule = "body { font-family: " + font.getFamily() + "; " +
+				"font-size: " + font.getSize() + "pt; }";
+		((HTMLDocument)component.getDocument()).getStyleSheet().addRule(bodyRule);
+		return component;
+	}
+
+	private Component createGeneralChoices() {
+		JPanel generalChoices = new JPanel();
+		generalChoices.setLayout(new MigLayout("flowy, insets n 0 n n", "", ""));
+		updateAll = createGeneralChoiceButton("Update all URLs (recommended)");
+		keepAll = createGeneralChoiceButton("Keep the current URLs");
+		manualChoice = createGeneralChoiceButton("Adjust manually:");
+		manualChoice.setFont(manualChoice.getFont().deriveFont(manualChoice.getFont().getStyle() & ~Font.BOLD));
+		generalChoices.add(updateAll);
+		generalChoices.add(keepAll);
+		generalChoices.add(manualChoice);
+		return generalChoices;
+	}
+
+	private JRadioButton createGeneralChoiceButton(String name) {
+		JRadioButton btn = new JRadioButton(name);
+		generalChoiceGroup.add(btn);
+		btn.addActionListener(this);
+		return btn;
+	}
+
+	private Component createButtonsPanel() {
+		final JPanel buttons = new JPanel();
+		buttons.setLayout(new MigLayout("", "[]push[][]", ""));
+		stopAsking = new JCheckBox("Remember to not update these URLs");
+		buttons.add(stopAsking);
+		cancel = SwingTools.button("Cancel", "Do not update software package sources", this, buttons);
+		submit = SwingTools.button("OK", "Continue with updated software package sources", this, buttons);
+		getRootPane().setDefaultButton(submit);
+		return buttons;
+	}
+
+	private Component createUpdateSiteScrollPane() {
+		JScrollPane scrollPane = new JScrollPane(createUpdatableSitesTable());
+		scrollPane.setPreferredSize(new Dimension(tableModel.tableWidth, 150));
+		scrollPane.setMinimumSize(new Dimension(0,0));
+		return scrollPane;
+	}
+
+	private JTable createUpdatableSitesTable() {
+		tableModel = new UpdatableTableDataModel();
+		table = new UpdatableSitesTable(tableModel);
+		table.setColumnSelectionAllowed(false);
+		table.setRowSelectionAllowed(false);
+		table.setRowHeight((int) (table.getRowHeight()*1.5));
+		table.setShowVerticalLines(false);
+		((DefaultTableCellRenderer)table.getTableHeader().getDefaultRenderer())
+				.setHorizontalAlignment(JLabel.LEFT);
+		table.setDefaultRenderer(URLChange.class, new URLRenderer());
+		TableColumn urlColumn = table.getColumnModel().getColumn(urlCol);
+		urlColumn.setCellEditor(new URLComboBoxEditor());
+		tableModel.setColumnWidths();
+		return table;
+	}
+
+	private static String wrapToolTip(final String description, final String maintainer) {
+		if (description == null) return null;
+		return  "<html><p width='400'>" + description.replaceAll("\n", "<br />")
+				+ (maintainer != null ? "</p><p>Maintainer: " + maintainer + "</p>": "")
+				+ "</p></html>";
+	}
+
+	private String getUpdateSiteName(int row) {
+		return getUpdateSite( row ).getName();
+	}
+
+	private UpdateSite getUpdateSite(int row) {
+		return getUrlChange(row).updateSite();
+	}
+
+	private URLChange getUrlChange(int row) {
+		return urlChanges.get(row);
+	}
+
+	private void updateGeneralChoices() {
+		int updated = 0;
+		int kept = 0;
+		for(URLChange change : urlChanges ) {
+			if(change.isApproved()) {
+				updated++;
+			} else {
+				kept++;
+			}
+		}
+		if(kept == 0) {
+			updateAll.setSelected(true);
+		}else {
+			if(updated == 0) {
+				keepAll.setSelected(true);
+			} else {
+				manualChoice.setSelected(true);
+			}
+		}
+		stopAsking.setEnabled(kept > 0);
+	}
+
+	private void submitAndDispose() {
+		okPressed = true;
+		if(stopAsking.isSelected()) {
+			// stop trying to update the URLs
+			urlChanges.forEach(change -> {
+				if(!change.isApproved()) {
+					change.updateSite().setKeepURL(true);
+				}
+			});
+		}
+		super.dispose();
+	}
+
+	private void keepAll() {
+		urlChanges.forEach(change -> change.setApproved(false));
+		stopAsking.setEnabled(true);
+		updateTable();
+	}
+
+	private void updateAll() {
+		urlChanges.forEach(change -> change.setApproved(true));
+		stopAsking.setEnabled(false);
+		updateTable();
+	}
+
+	private void updateTable() {
+		tableModel.fireTableRowsUpdated(0, tableModel.getRowCount()-1);
+	}
+
+	@Override
+	public void actionPerformed(ActionEvent e) {
+		if(e.getSource().equals(ok)) super.dispose();
+		else if(e.getSource().equals(cancel)) dispose();
+		else if(e.getSource().equals(submit)) submitAndDispose();
+		else if(e.getSource().equals(updateAll)) updateAll();
+		else if(e.getSource().equals(keepAll)) keepAll();
+	}
+
+	@Override
+	public void dispose() {
+		//reset choices, don't save available updated URLs and continue update
+		urlChanges.forEach(change -> change.setApproved(false));
+		super.dispose();
+	}
+
+	private class UpdatableTableDataModel extends DefaultTableModel {
+
+		int tableWidth;
+		int[] widths = { 130, 350 };
+		String[] headers = { "Name", "Choice" };
+
+		void setColumnWidths() {
+			final TableColumnModel columnModel = table.getColumnModel();
+			for (int i = 0; i < tableModel.widths.length && i < getColumnCount(); i++)
+			{
+				final TableColumn column = columnModel.getColumn(i);
+				column.setPreferredWidth(tableModel.widths[i]);
+				column.setMinWidth(tableModel.widths[i]);
+				tableWidth += tableModel.widths[i];
+			}
+			columnModel.getColumn(nameCol).setMaxWidth(tableModel.widths[nameCol]);
+		}
+
+		@Override
+		public int getColumnCount() {
+			return 2;
+		}
+
+		@Override
+		public String getColumnName(final int column) {
+			return headers[column];
+		}
+
+		@Override
+		public Class<?> getColumnClass(final int column) {
+			if(column != nameCol) return URLChange.class;
+			return String.class;
+		}
+
+		@Override
+		public int getRowCount() {
+			return urlChanges.size();
+		}
+
+		@Override
+		public Object getValueAt(final int row, final int col) {
+			if (col == nameCol) return getUpdateSiteName(row);
+			if (col == urlCol) return getUrlChange(row);
+			return null;
+		}
+	}
+
+	private String keepChoiceString(URLChange site) {
+		return "<html><b>" + site.updateSite().getURL() + "</b>" + appendOld;
+	}
+
+	private String updateChoiceString(URLChange site) {
+		return  "<html><b>" + site.getNewURL() + "</b>" + appendNew;
+	}
+
+	private class URLComboBoxEditor extends DefaultCellEditor {
+
+		private final JComboBox<String> box = new JComboBox<>();
+		private final TableCellEditor editor = new DefaultCellEditor(box);
+
+		URLComboBoxEditor() {
+			super(new JComboBox());
+			box.addPopupMenuListener(new PopupMenuListener() {
+				@Override
+				public void popupMenuWillBecomeVisible(PopupMenuEvent e) {}
+				@Override
+				public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {stopCellEditing();}
+				@Override
+				public void popupMenuCanceled(PopupMenuEvent e) {stopCellEditing();}
+			});
+			box.setFont(box.getFont().deriveFont(box.getFont().getStyle() & ~Font.BOLD));
+		}
+
+		@Override
+		public Object getCellEditorValue() {
+			return editor.getCellEditorValue();
+		}
+
+		@Override
+		public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
+			URLChange change = getUrlChange(row);
+			box.removeAllItems();
+			box.addItem(keepChoiceString( change ));
+			box.addItem(updateChoiceString( change ));
+			box.setSelectedIndex( change.isApproved() ? 1 : 0);
+			return editor.getTableCellEditorComponent(table, value, isSelected, row, column);
+		}
+	}
+
+	private class UpdatableSitesTable extends JTable {
+		UpdatableSitesTable(UpdatableTableDataModel tableModel) {
+			super(tableModel);
+		}
+
+		@Override
+		public void valueChanged(final ListSelectionEvent e) {
+			super.valueChanged(e);
+		}
+
+		@Override
+		public boolean isCellEditable(final int row, final int column) {
+			return column > 0;
+		}
+
+		@Override
+		public void setValueAt(final Object value, final int row, final int column)
+		{
+			URLChange change = getUrlChange(row);
+			if(column == urlCol) {
+				if(value.equals(keepChoiceString( change ))) {
+					change.setApproved(false);
+				}
+				if(value.equals(updateChoiceString( change ))) {
+					change.setApproved(true);
+				}
+				tableModel.fireTableRowsUpdated(row, row);
+				updateGeneralChoices();
+			}
+		}
+
+		@Override
+		public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
+			Component component = super.prepareRenderer(renderer, row, column);
+			if (component instanceof JComponent) {
+				final UpdateSite site = getUpdateSite(row);
+				if (site != null) {
+					JComponent jcomponent = (JComponent) component;
+					jcomponent.setToolTipText(wrapToolTip(site.getDescription(), site.getMaintainer()));
+				}
+			}
+			return component;
+		}
+	}
+
+	private class URLRenderer extends JLabel implements TableCellRenderer {
+
+		URLPanel panel = new URLPanel();
+
+		@Override
+		public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+		                                               boolean hasFocus, int rowIndex, int vColIndex) {
+			if(value == null) return null;
+			panel.update( (URLChange) value );
+			return panel;
+		}
+	}
+
+	private class URLPanel extends JPanel {
+
+		JLabel urlLabel, choiceLabel;
+
+		URLPanel() {
+			setLayout(new MigLayout("fill"));
+			setOpaque(false);
+			urlLabel = new JLabel();
+			choiceLabel = new JLabel();
+			choiceLabel.setFont(choiceLabel.getFont().deriveFont(choiceLabel.getFont().getStyle() & ~Font.BOLD));
+			choiceLabel.setBorder(BorderFactory.createEmptyBorder(0,0,0,10));
+			add(urlLabel, "dock west");
+			add(choiceLabel, "dock east");
+		}
+
+		public void update(URLChange change ) {
+			urlLabel.setText( change.isApproved() ? change.getNewURL() : change.updateSite().getURL());
+			choiceLabel.setText( change.isApproved() ? appendNew : appendOld );
+		}
+
+	}
+}

--- a/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
+++ b/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
@@ -72,6 +72,7 @@ import javax.swing.table.TableColumnModel;
 import net.imagej.updater.FilesCollection;
 import net.imagej.updater.UpdateSite;
 import net.imagej.updater.UploaderService;
+import net.imagej.updater.util.HTTPSUtil;
 import net.imagej.updater.util.UpdaterUtil;
 import net.imagej.util.MediaWikiClient;
 import net.miginfocom.swing.MigLayout;
@@ -145,6 +146,15 @@ public class SitesDialog extends JDialog implements ActionListener {
 							if ("/".equals(value)) value = "";
 							final UpdateSite site = getUpdateSite(row);
 							if (value.equals(site.getURL())) return super.stopCellEditing();
+							if(!HTTPSUtil.supportsURLProtocol(value)) {
+								if(showYesNoQuestion("Convert HTTPS URL to HTTP?",
+										"Your installation cannot handle secure communication (HTTPS).\n" +
+												"Please download a recent version of this software.\n\n" +
+												"Do you want to use the insecure URL of this update site (HTTP)?")) {
+									value = HTTPSUtil.userSiteConvertToHTTP(value);
+									field.setText(value);
+								} else return false;
+							}
 							if (validURL(value)) {
 								site.setURL(value);
 								boolean wasActive = site.isActive();
@@ -298,7 +308,7 @@ public class SitesDialog extends JDialog implements ActionListener {
 		}
 	}
 
-	private final static String PERSONAL_SITES_URL = "http://sites.imagej.net/";
+	private final static String PERSONAL_SITES_URL = HTTPSUtil.getProtocol() + "sites.imagej.net/";
 
 	private void addPersonalSite() {
 		final PersonalSiteDialog dialog = new PersonalSiteDialog();

--- a/src/test/java/net/imagej/ui/swing/updater/ReviewSiteURLsDialogDemo.java
+++ b/src/test/java/net/imagej/ui/swing/updater/ReviewSiteURLsDialogDemo.java
@@ -1,0 +1,24 @@
+package net.imagej.ui.swing.updater;
+
+import net.imagej.updater.URLChange;
+import net.imagej.updater.UpdateSite;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+public class ReviewSiteURLsDialogDemo {
+
+	public static void main(String...  args) {
+		List<URLChange> changes = new ArrayList<>();
+		changes.add(URLChange.create(createUpdateSite("a", "https://downloads.micron.ox.ac.uk"),
+				"https://better.a.com").get());
+		changes.add(URLChange.create(createUpdateSite("b", "https://b.com"),
+				"https://better.a.com").get());
+		new ReviewSiteURLsDialog(null, changes).setVisible(true);
+	}
+
+	private static UpdateSite createUpdateSite(String b, String url) {
+		return new UpdateSite(b, url, "", "", "Great Update Site", "Best Maintainer in the World", 0);
+	}
+}

--- a/src/test/java/net/imagej/ui/swing/updater/ReviewSiteURLsDialogTest.java
+++ b/src/test/java/net/imagej/ui/swing/updater/ReviewSiteURLsDialogTest.java
@@ -1,0 +1,302 @@
+package net.imagej.ui.swing.updater;
+
+import net.imagej.updater.FilesCollection;
+import net.imagej.updater.URLChange;
+import net.imagej.updater.UpdateSite;
+import net.imagej.updater.util.AvailableSites;
+import net.imagej.updater.util.HTTPSUtil;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.awt.event.ActionEvent;
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
+
+public class ReviewSiteURLsDialogTest {
+
+	@Rule
+	public TemporaryFolder root = new TemporaryFolder();
+
+	@Test
+	public void deactivatedSitesTest() {
+
+		// initialize files collection
+		FilesCollection files = new FilesCollection(root.getRoot());
+
+		// add an official update site
+		UpdateSite siteA = createOfficialSite("a", "http://sites.imagej.net/a/");
+		files.addUpdateSite(siteA);
+
+		// this will propose a change to the URL
+		Optional< URLChange > urlChange =
+				URLChange.create(siteA, "http://sites.imagej.net/b/");
+		assertTrue(urlChange.isPresent());
+		assertEquals("http://sites.imagej.net/b/", urlChange.get().getNewURL());
+
+		// the change should be accepted without showing a user interface since the site is deactivated
+		List< URLChange > changes = Collections.singletonList(urlChange.get());
+		assertFalse(ReviewSiteURLsDialog.shouldBeDisplayed(changes));
+
+		// apply the change to the URL
+		AvailableSites.applySitesURLUpdates(files, changes);
+
+		// test if the change to the URL was applied
+		assertEquals("http://sites.imagej.net/b/", siteA.getURL());
+	}
+
+	@Test
+	public void cancelBtnTest() {
+
+		// initialize files collection
+		FilesCollection files = new FilesCollection(root.getRoot());
+
+		// add an official update site and activate it
+		UpdateSite siteA = createOfficialSite("a", "http://sites.imagej.net/a/");
+		siteA.setActive(true);
+		files.addUpdateSite(siteA);
+
+		// propose a change to the site URL
+		Optional< URLChange > change =
+				URLChange.create(siteA, "http://sites.imagej.net/b/");
+
+		// this change should be approved by the user since the update site is active
+		List< URLChange > changes = Collections.singletonList(change.get());
+		assertTrue(ReviewSiteURLsDialog.shouldBeDisplayed(changes));
+
+		// create review dialog
+		ReviewSiteURLsDialog
+				dialog = new ReviewSiteURLsDialog(null, changes);
+
+		// trigger cancel button
+		dialog.actionPerformed(createActionEvent(dialog.cancel));
+
+		// apply changes to update site URLs
+		AvailableSites.applySitesURLUpdates(files, changes);
+
+		// test if change to URL got reverted
+		assertEquals("http://sites.imagej.net/a/", siteA.getURL());
+	}
+
+	@Test
+	public void submitBtnTest() {
+
+		// initialize files collection
+		FilesCollection files = new FilesCollection(root.getRoot());
+
+		// add an official update site and activate it
+		UpdateSite siteA = createOfficialSite("a", "http://sites.imagej.net/a/");
+		siteA.setActive(true);
+		files.addUpdateSite(siteA);
+
+		// propose a change to the site URL
+		Optional< URLChange > urlChange =
+				URLChange.create(siteA, "http://sites.imagej.net/b/");
+		List< URLChange > urlChanges = Collections.singletonList(urlChange.get());
+
+		// create review dialog
+		ReviewSiteURLsDialog
+				dialog = new ReviewSiteURLsDialog(null, urlChanges);
+
+		// trigger submit button
+		dialog.actionPerformed(createActionEvent(dialog.submit));
+
+		// apply changes to update site URLs
+		AvailableSites.applySitesURLUpdates(files, urlChanges);
+
+		// test if change to URL got applied
+		assertEquals("http://sites.imagej.net/b/", siteA.getURL());
+	}
+
+	@Test
+	public void keepAllTest() {
+
+		// initialize files collection
+		FilesCollection files = new FilesCollection(root.getRoot());
+
+		// add an official update site and activate it
+		UpdateSite siteA = createOfficialSite("a", "http://sites.imagej.net/a/");
+		siteA.setActive(true);
+		files.addUpdateSite(siteA);
+
+		// add automated change to the URL
+		URLChange change = URLChange.create(siteA, "http://newdomain.net/a/").get();
+		List< URLChange > changes = Collections.singletonList(change);
+
+		// since the update site is active, the change needs to be approved, therefore the dialog should be displayed
+		assertTrue(change.isRecommended());
+		assertTrue(ReviewSiteURLsDialog.shouldBeDisplayed(changes));
+
+		// create review dialog
+		ReviewSiteURLsDialog dialog = new ReviewSiteURLsDialog(null, changes);
+
+		// trigger action to mark all changes to URLs as disapproved
+		dialog.actionPerformed(createActionEvent(dialog.keepAll));
+
+		// test if site lost URL update approval
+		assertFalse(change.isApproved());
+
+		// test if option to remember choice is activated
+		assertFalse(dialog.stopAsking.isSelected());
+
+		// trigger submit action
+		dialog.actionPerformed(createActionEvent(dialog.submit));
+
+		// apply changes
+		AvailableSites.applySitesURLUpdates(files, changes);
+
+		// test whether the old update site URL is still in use
+		assertEquals("http://sites.imagej.net/a/", siteA.getURL());
+		assertFalse(siteA.shouldKeepURL());
+	}
+
+	@Test
+	public void rememberKeptChoicesTest() {
+
+		// initialize files collection
+		FilesCollection files = new FilesCollection(root.getRoot());
+
+		// add an official update site and activate it
+		UpdateSite siteA = createOfficialSite("a", "http://sites.imagej.net/a/");
+		siteA.setActive(true);
+		files.addUpdateSite(siteA);
+
+		// add automated change to the URL
+		URLChange change = URLChange.create(siteA, "http://newdomain.net/a/").get();
+		List< URLChange > changes = Collections.singletonList(change);
+
+		// create review dialog
+		ReviewSiteURLsDialog dialog = new ReviewSiteURLsDialog(null, changes);
+
+		// trigger action to mark all changes to URLs as disapproved
+		dialog.actionPerformed(createActionEvent(dialog.keepAll));
+
+		// trigger toggle to remember choice
+		dialog.stopAsking.setSelected(true);
+
+		// trigger submit action
+		dialog.actionPerformed(createActionEvent(dialog.submit));
+
+		// apply changes
+		AvailableSites.applySitesURLUpdates(files,changes);
+
+		// test whether the old update site URL is still in use
+		assertEquals("http://sites.imagej.net/a/", siteA.getURL());
+		assertTrue(siteA.shouldKeepURL());
+
+		// again add automated change to URL
+		URLChange change2 = URLChange.create(siteA, "http://newdomain.net/a/").get();
+		// test whether the choice of keeping the old URL is remembered
+		assertFalse(change2.isRecommended());
+		assertFalse(change2.isApproved());
+		assertFalse(ReviewSiteURLsDialog.shouldBeDisplayed(Collections.singletonList(change2)));
+	}
+
+	@Test
+	public void httpsUpgradeTest() {
+
+		// check if HTTPS is supported, if not, ignore test
+		HTTPSUtil.checkHTTPSSupport(null);
+		assumeTrue(HTTPSUtil.supportsHTTPS());
+
+		// initialize files collection
+		FilesCollection files = new FilesCollection(root.getRoot());
+
+		// add an official update site
+		UpdateSite siteA = createOfficialSite("a", "http://sites.imagej.net/a/");
+		URLChange changeInactiveSite =
+				URLChange.create(siteA, "https://sites.imagej.net/a/").get();
+
+		// the change should be accepted without showing a user interface since the site is deactivated
+		assertFalse(ReviewSiteURLsDialog.shouldBeDisplayed(Collections.singletonList(changeInactiveSite)));
+
+		// add another official update site, activate it
+		UpdateSite siteB = createOfficialSite("b", "http://sites.imagej.net/b/");
+		siteB.setActive(true);
+		URLChange changeActiveSite =
+				URLChange.create(siteB, "https://sites.imagej.net/b/").get();
+
+		// the change should be accepted after showing a user interface since one site is activated
+		List<URLChange> changes = Arrays.asList(changeActiveSite, changeInactiveSite);
+		assertTrue(ReviewSiteURLsDialog.shouldBeDisplayed(Collections.singletonList(changeActiveSite)));
+
+		// create review dialog
+		ReviewSiteURLsDialog dialog = new ReviewSiteURLsDialog(null, changes);
+		assertEquals(2, dialog.urlChanges.size());
+
+		// apply the change to the URL
+		AvailableSites.applySitesURLUpdates(files, changes);
+
+		// test if the change to the URL was applied
+		assertEquals("https://sites.imagej.net/a/", siteA.getURL());
+		assertEquals("https://sites.imagej.net/b/", siteB.getURL());
+		assertFalse(siteA.shouldKeepURL());
+		assertFalse(siteB.shouldKeepURL());
+	}
+
+	@Test
+	public void httpDowngradeTest() {
+
+		// check if HTTPS is not supported, otherwise ignore test
+		HTTPSUtil.checkHTTPSSupport(null);
+		assumeFalse(HTTPSUtil.supportsHTTPS());
+
+		// initialize files collection
+		FilesCollection files = new FilesCollection(root.getRoot());
+
+		// add an official update site
+		UpdateSite siteA = createOfficialSite("a", "https://sites.imagej.net/a/");
+		files.addUpdateSite(siteA);
+
+		// create list to hold changes to update site URLs
+		List<URLChange> urlChanges = new ArrayList<>();
+
+		// check if update site URL has to be changed
+		Optional< URLChange > changeA = URLChange.create(siteA,
+				HTTPSUtil.fixImageJUserSiteProtocol(siteA.getURL()));
+		changeA.ifPresent( urlChanges::add );
+
+		// the change should be accepted without showing a user interface since the site is deactivated
+		assertFalse(ReviewSiteURLsDialog.shouldBeDisplayed(urlChanges));
+
+		// add another official update site, activate it
+		UpdateSite siteB = createOfficialSite("b", "https://sites.imagej.net/b/");
+		siteB.setActive(true);
+		files.addUpdateSite(siteB);
+
+		// check if update site URL has to be changed
+		Optional< URLChange > changeB = URLChange.create(siteB,
+				HTTPSUtil.fixImageJUserSiteProtocol(siteB.getURL()));
+		changeB.ifPresent( urlChanges::add );
+
+		// the change should be accepted after showing a user interface since one site is activated
+		assertTrue(ReviewSiteURLsDialog.shouldBeDisplayed(urlChanges));
+
+		// create review dialog
+		ReviewSiteURLsDialog dialog = new ReviewSiteURLsDialog(null, urlChanges);
+		assertEquals(2, dialog.urlChanges.size());
+
+		// apply the change to the URL
+		AvailableSites.applySitesURLUpdates(files, urlChanges);
+
+		// test if the change to the URL was applied
+		assertEquals("http://sites.imagej.net/a/", siteA.getURL());
+		assertEquals("http://sites.imagej.net/b/", siteB.getURL());
+		assertFalse(siteA.shouldKeepURL());
+		assertFalse(siteB.shouldKeepURL());
+	}
+
+	private ActionEvent createActionEvent(Object source) {
+		return new ActionEvent(source, 0, "");
+	}
+
+	private UpdateSite createOfficialSite(String name, String url) {
+		UpdateSite site = new UpdateSite(name, url, "", "", "", "", 0);
+		site.setOfficial(true);
+		return site;
+	}
+
+}


### PR DESCRIPTION
This adds a dialog to the update procedure where the user can review changes to URLs of enabled update sites coming from the list of available update sites.

It depends on https://github.com/imagej/imagej-updater/pull/71.

![screenshot_2019-02-27_00-48-52](https://user-images.githubusercontent.com/708121/53455032-81f68e00-3a29-11e9-9049-75c03bba5c96.png)
