### PR TITLE
Do not update the updater separately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ branches:
 install: true
 services:
   - xvfb
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
 script: ".travis/build.sh"
 env:
   global:


### PR DESCRIPTION
The removed code does the following:
  * check if the updater can be updated
  * if yes, download updater and it's dependencies and install it, do not ask for approval
  * try to restart the updater in place
  * if that does not work, ask for restart of Fiji

This is why it should be removed:
  * if other components depend on the updater, this can break the updater because the other component will not get updated at the same time as the updater
  * the updater will be updated without the users approval