### PR TITLE
Upgrade to miglayout-swing-5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 
 		<imagej-updater.version>0.10.1</imagej-updater.version>
+		<miglayout-swing.version>5.2</miglayout-swing.version>
 	</properties>
 
 	<repositories>
@@ -181,17 +182,29 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-ui-awt</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.miglayout</groupId>
+					<artifactId>miglayout</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-ui-swing</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.miglayout</groupId>
+					<artifactId>miglayout</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- Third-party dependencies -->
 		<dependency>
 			<groupId>com.miglayout</groupId>
-			<artifactId>miglayout</artifactId>
-			<classifier>swing</classifier>
+			<artifactId>miglayout-swing</artifactId>
+			<version>${miglayout-swing.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jfree</groupId>


### PR DESCRIPTION
This requires temporary exclusion of the incompatible dependencies in `scijava-ui-awt` and `scijava-ui-swing`.

* The exclusions can be removed once https://github.com/scijava/scijava-ui-awt/pull/1 and https://github.com/scijava/scijava-ui-swing/pull/46 are both merged and released.
* The version pinning can be removed once we have a `pom-scijava` release managing this version (see https://github.com/scijava/pom-scijava/pull/97).
