### PR TITLE
SwingColorTableWidget: Adopt scalable height

### DIFF
--- a/src/main/java/net/imagej/ui/swing/SwingColorBar.java
+++ b/src/main/java/net/imagej/ui/swing/SwingColorBar.java
@@ -54,7 +54,6 @@ import org.scijava.ui.awt.AWTImageTools;
 public final class SwingColorBar extends JComponent {
 
 	private static final int DEFAULT_HEIGHT = 24;
-
 	private final int height;
 
 	private BufferedImage bar;

--- a/src/main/java/net/imagej/ui/swing/widget/SwingColorTableWidget.java
+++ b/src/main/java/net/imagej/ui/swing/widget/SwingColorTableWidget.java
@@ -29,12 +29,15 @@
 
 package net.imagej.ui.swing.widget;
 
+import java.awt.Insets;
 import java.awt.image.BufferedImage;
 
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.UIManager;
 
+import net.imagej.ui.swing.updater.SwingTools;
 import net.imagej.widget.ColorTableWidget;
 import net.imglib2.display.ColorTable;
 
@@ -57,11 +60,13 @@ public class SwingColorTableWidget extends SwingInputWidget<ColorTable>
 
 	private BufferedImage image;
 	private JLabel picLabel;
+	private final int height;
 
 	// -- constructors --
 
 	public SwingColorTableWidget() {
-		image = new BufferedImage(256, 20, BufferedImage.TYPE_INT_RGB);
+		height = colorBarHeight();
+		image = new BufferedImage(256, height, BufferedImage.TYPE_INT_RGB);
 	}
 
 	// -- InputWidget methods --
@@ -102,9 +107,20 @@ public class SwingColorTableWidget extends SwingInputWidget<ColorTable>
 			int g = cTable.get(1, x) & 0xff;
 			int b = cTable.get(2, x) & 0xff;
 			int rgb = (r << 16) | (g << 8) | b;
-			for (int y = 0; y < 20; y++) {
+			for (int y = 0; y < height; y++) {
 				image.setRGB(x, y, rgb);
 			}
 		}
 	}
+
+	private static int colorBarHeight() {
+		try {
+			final Insets insets = UIManager.getInsets("TextPane.margin");
+			return UIManager.getFont("TextField.font").getSize() + insets.top + insets.bottom;
+		} catch (final Exception ignored) {
+			// do nothing
+		}
+		return 24;
+	}
+
 }


### PR DESCRIPTION
Currently, the height of SwingColorTableWidget is hardwired at 20 pixels, which in hiDPI screens is too small. This makes it so that the widget is scaled to the height of a JTexField. Here is a before/after comparison (1.5x scaling factor):

![image](https://user-images.githubusercontent.com/2439948/193482308-5d2898b8-2410-4809-b13a-2844fbd7757d.png)

The width is still hardwired to 256.