### PR TITLE
 Filter-as-you-type functionality for site list and fixes for Look and Feel

### DIFF
--- a/src/main/java/net/imagej/ui/swing/updater/ConflictDialog.java
+++ b/src/main/java/net/imagej/ui/swing/updater/ConflictDialog.java
@@ -83,7 +83,6 @@ public abstract class ConflictDialog extends JDialog implements ActionListener {
 
 		bold = new SimpleAttributeSet();
 		StyleConstants.setBold(bold, true);
-		StyleConstants.setFontSize(bold, 16);
 		indented = new SimpleAttributeSet();
 		StyleConstants.setLeftIndent(indented, 40);
 		italic = new SimpleAttributeSet();
@@ -95,8 +94,9 @@ public abstract class ConflictDialog extends JDialog implements ActionListener {
 		SwingTools.scrollPane(panel, 650, 450, rootPanel);
 
 		final JPanel buttons = new JPanel();
-		ok = SwingTools.button("OK", "OK", this, buttons);
-		cancel = SwingTools.button("Cancel", "Cancel", this, buttons);
+		ok = SwingTools.button("OK", "Apply resolutions [Enter]", this, buttons);
+		cancel = SwingTools.button("Cancel", "Dismiss [Esc]", this, buttons);
+		buttons.setMaximumSize(buttons.getPreferredSize()); // do not allow vertical resizing
 		rootPanel.add(buttons);
 
 		// do not show, right now
@@ -136,13 +136,7 @@ public abstract class ConflictDialog extends JDialog implements ActionListener {
 	public void setVisible(final boolean visible) {
 		if (SwingUtilities.isEventDispatchThread()) super.setVisible(visible);
 		else try {
-			SwingUtilities.invokeAndWait(new Runnable() {
-
-				@Override
-				public void run() {
-					setVisible(visible);
-				}
-			});
+			SwingUtilities.invokeAndWait(() -> setVisible(visible));
 		}
 		catch (final InterruptedException e) {
 			updaterFrame.log.error(e);
@@ -174,13 +168,9 @@ public abstract class ConflictDialog extends JDialog implements ActionListener {
 			addText("\n");
 			for (final Resolution resolution : conflict.getResolutions()) {
 				addText("\n    ");
-				addButton(resolution.getDescription(), new ActionListener() {
-
-					@Override
-					public void actionPerformed(final ActionEvent e) {
-						resolution.resolve();
-						listIssues();
-					}
+				addButton(resolution.getDescription(), e -> {
+					resolution.resolve();
+					listIssues();
 				});
 			}
 		}

--- a/src/main/java/net/imagej/ui/swing/updater/DiffFile.java
+++ b/src/main/java/net/imagej/ui/swing/updater/DiffFile.java
@@ -126,17 +126,14 @@ public class DiffFile extends JFrame {
 	 *            the mode to diff to
 	 */
 	protected void show(final Mode mode) {
-		show(new Runnable() {
-			@Override
-			public void run() {
-				try {
-					setTitle(title + " (" + mode + ")");
-					diff.showDiff(filename, remote, local, mode);
-				} catch (MalformedURLException e) {
-					log.error(e);
-				} catch (IOException e) {
-					log.error(e);
-				}
+		show(() -> {
+			try {
+				setTitle(title + " (" + mode + ")");
+				diff.showDiff(filename, remote, local, mode);
+			} catch (MalformedURLException e) {
+				log.error(e);
+			} catch (IOException e) {
+				log.error(e);
 			}
 		});
 	}
@@ -265,22 +262,14 @@ public class DiffFile extends JFrame {
 
 		if (diffView.getDocument().getLength() > 0)
 			diffView.normal(" ");
-		diffView.link("Git Log", new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				show(new Runnable() {
-					@Override
-					public void run() {
-						setTitle(title + " (Git Log)");
-						final PrintStream out = diffView.getPrintStream();
-						out.println("\n");
-						if (warning != null) diffView.warn(warning + "\n\n");
-						final String git = System.getProperty("imagej.updater.git.command", "git");
-						ProcessUtils.exec(gitWorkingDirectory,  out, out, git, "log", "-M", "-p", since, commitRange, "--", relativePath);
-					}
-				});
-			}
-		});
+		diffView.link("Git Log", e -> show(() -> {
+			setTitle(title + " (Git Log)");
+			final PrintStream out = diffView.getPrintStream();
+			out.println("\n");
+			if (warning != null) diffView.warn(warning + "\n\n");
+			final String git = System.getProperty("imagej.updater.git.command", "git");
+			ProcessUtils.exec(gitWorkingDirectory,  out, out, git, "log", "-M", "-p", since, commitRange, "--", relativePath);
+		}));
 	}
 
 	/**

--- a/src/main/java/net/imagej/ui/swing/updater/DiffView.java
+++ b/src/main/java/net/imagej/ui/swing/updater/DiffView.java
@@ -73,8 +73,9 @@ public class DiffView extends JScrollPane {
 	private static final long serialVersionUID = 1L;
 
 	protected static final String ACTION_ATTRIBUTE = "ACTION";
-	protected static final String FONT = "Courier";
-	protected static final int FONT_SIZE = 12, BIG_FONT_SIZE = 15;
+	protected static final String FONT = java.awt.Font.MONOSPACED;
+	protected static final int FONT_SIZE = SwingTools.defaultFontSize();
+	protected static final int BIG_FONT_SIZE = (int) 1.25 * FONT_SIZE;
 
 	protected JPanel panel;
 	protected JTextPane textPane;
@@ -94,10 +95,10 @@ public class DiffView extends JScrollPane {
 		panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
 		getViewport().setView(panel);
 
-		normal = getStyle(Color.black, false, false, FONT, FONT_SIZE);
+		normal = getStyle(null, false, false, FONT, FONT_SIZE);
 		bigBold = getStyle(Color.blue, false, true, FONT, BIG_FONT_SIZE);
-		bold = getStyle(Color.black, false, true, FONT, FONT_SIZE);
-		italic = getStyle(Color.black, true, false, FONT, FONT_SIZE);
+		bold = getStyle(null, false, true, FONT, FONT_SIZE);
+		italic = getStyle(null, true, false, FONT, FONT_SIZE);
 		red = getStyle(Color.red, false, false, FONT, FONT_SIZE);
 		green = getStyle(new Color(0, 128, 32), false, false, FONT, FONT_SIZE);
 
@@ -144,7 +145,7 @@ public class DiffView extends JScrollPane {
 	public static SimpleAttributeSet getStyle(Color color, boolean italic,
 			boolean bold, String fontName, int fontSize) {
 		SimpleAttributeSet style = new SimpleAttributeSet();
-		StyleConstants.setForeground(style, color);
+		if (color != null) StyleConstants.setForeground(style, color);
 		StyleConstants.setItalic(style, italic);
 		StyleConstants.setBold(style, bold);
 		StyleConstants.setFontFamily(style, fontName);

--- a/src/main/java/net/imagej/ui/swing/updater/FileDetails.java
+++ b/src/main/java/net/imagej/ui/swing/updater/FileDetails.java
@@ -52,7 +52,9 @@ import javax.swing.text.Document;
 import javax.swing.text.Element;
 import javax.swing.text.Position;
 import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.Style;
 import javax.swing.text.StyleConstants;
+import javax.swing.text.StyleContext;
 import javax.swing.text.StyledDocument;
 
 import net.imagej.updater.FileObject;
@@ -75,11 +77,11 @@ public class FileDetails extends JTextPane implements UndoableEditListener {
 	UpdaterFrame updaterFrame;
 
 	static {
-		italic = getStyle(Color.black, true, false, "Verdana", 12);
-		bold = getStyle(Color.black, false, true, "Verdana", 12);
-		normal = getStyle(Color.black, false, false, "Verdana", 12);
-		title = getStyle(Color.black, false, false, "Impact", 18);
-
+		final int size = SwingTools.defaultFontSize();
+		italic = getStyle(null, true, false, java.awt.Font.SANS_SERIF, size);
+		bold = getStyle(null, false, true, java.awt.Font.SANS_SERIF, size);
+		normal = getStyle(null, false, false, java.awt.Font.SANS_SERIF, size);
+		title = getStyle(null, false, false, java.awt.Font.SANS_SERIF, (int)1.5 * size);
 		hand = new Cursor(Cursor.HAND_CURSOR);
 		defaultCursor = new Cursor(Cursor.DEFAULT_CURSOR);
 	}
@@ -116,14 +118,7 @@ public class FileDetails extends JTextPane implements UndoableEditListener {
 	public void reset() {
 		setEditable(false);
 		setText("");
-		final Comparator<Position> comparator = new Comparator<Position>() {
-
-			@Override
-			public int compare(final Position p1, final Position p2) {
-				return p1.getOffset() - p2.getOffset();
-			}
-		};
-
+		final Comparator<Position> comparator = (p1, p2) -> p1.getOffset() - p2.getOffset();
 		editables = new TreeMap<>(comparator);
 		dummySpace = null;
 	}
@@ -144,10 +139,8 @@ public class FileDetails extends JTextPane implements UndoableEditListener {
 	}
 
 	private AttributeSet getLinkAttribute(final String url) {
-		// TODO: Verdana? Java is platform-independent, if this introduces a
-		// platform dependency, it needs to be thrown out, quickly!
-		final SimpleAttributeSet style =
-			getStyle(Color.blue, false, false, "Verdana", 12);
+		final Style style = StyleContext.getDefaultStyleContext().getStyle(StyleContext.DEFAULT_STYLE);
+		StyleConstants.setForeground(style, Color.BLUE);
 		style.addAttribute(LINK_ATTRIBUTE, url);
 		return style;
 	}
@@ -157,10 +150,10 @@ public class FileDetails extends JTextPane implements UndoableEditListener {
 		final int fontSize)
 	{
 		final SimpleAttributeSet style = new SimpleAttributeSet();
-		StyleConstants.setForeground(style, color);
+		if (color != null) StyleConstants.setForeground(style, color);
 		StyleConstants.setItalic(style, italic);
 		StyleConstants.setBold(style, bold);
-		StyleConstants.setFontFamily(style, fontName);
+		if (fontName != null) StyleConstants.setFontFamily(style, fontName);
 		StyleConstants.setFontSize(style, fontSize);
 		return style;
 	}

--- a/src/main/java/net/imagej/ui/swing/updater/FileDetails.java
+++ b/src/main/java/net/imagej/ui/swing/updater/FileDetails.java
@@ -208,7 +208,7 @@ public class FileDetails extends JTextPane implements UndoableEditListener {
 		if (!updaterFrame.files.hasUploadableSites() &&
 			(description == null || description.trim().equals(""))) return;
 		blankLine();
-		bold("Description" + (file.descriptionFromPOM ? " (from pom.xml):" : ":") + ":\n");
+		bold("Description" + (file.descriptionFromPOM ? " (from pom.xml)" : "") + ":\n");
 		final int offset = getCaretPosition();
 		normal(description);
 		if (!file.descriptionFromPOM)
@@ -291,7 +291,7 @@ public class FileDetails extends JTextPane implements UndoableEditListener {
 			normal(prettyPrintTimestamp(file.current.timestamp));
 		}
 		description(file.getDescription(), file);
-		list("Author:", false, file.getAuthors(), ", ", file);
+		list("Author", false, file.getAuthors(), ", ", file);
 		if (updaterFrame.files.hasUploadableSites()) list("Platform", false, file
 			.getPlatforms(), ", ", file);
 		list("Category", false, file.getCategories(), ", ", file);

--- a/src/main/java/net/imagej/ui/swing/updater/ImageJUpdater.java
+++ b/src/main/java/net/imagej/ui/swing/updater/ImageJUpdater.java
@@ -124,12 +124,7 @@ public class ImageJUpdater implements UpdaterUI {
 		UpdaterUtil.useSystemProxies();
 		Authenticator.setDefault(new SwingAuthenticator());
 
-		SwingTools.invokeOnEDT(new Runnable() {
-			@Override
-			public void run() {
-				main = new UpdaterFrame(log, uploaderService, files);
-			}
-		});
+		SwingTools.invokeOnEDT(() -> main = new UpdaterFrame(log, uploaderService, files));
 
 		main.setEasyMode(true);
 		Progress progress = main.getProgress("Starting up...");
@@ -148,7 +143,7 @@ public class ImageJUpdater implements UpdaterUI {
 			if (!warnings.equals("")) main.warn(warnings);
 			final List<Conflict> conflicts = files.getConflicts();
 			if (conflicts != null && conflicts.size() > 0 &&
-					!new ConflictDialog(main, "Conflicting versions") {
+					!new ConflictDialog(main, "Conflicting Versions") {
 						private static final long serialVersionUID = 1L;
 
 						@Override

--- a/src/main/java/net/imagej/ui/swing/updater/ProgressDialog.java
+++ b/src/main/java/net/imagej/ui/swing/updater/ProgressDialog.java
@@ -33,8 +33,6 @@ import java.awt.Adjustable;
 import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Frame;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.AdjustmentEvent;
 import java.awt.event.AdjustmentListener;
 import java.awt.event.KeyAdapter;
@@ -85,22 +83,12 @@ public class ProgressDialog extends JDialog implements Progress {
 
 		final JPanel buttons = new JPanel();
 		detailsToggle = new JButton("Show Details");
-		detailsToggle.addActionListener(new ActionListener() {
-
-			@Override
-			public void actionPerformed(final ActionEvent event) {
-				toggleDetails();
-			}
-		});
+		detailsToggle.addActionListener(event -> toggleDetails());
 		buttons.add(detailsToggle);
 		final JButton cancel = new JButton("Cancel");
-		cancel.addActionListener(new ActionListener() {
-
-			@Override
-			public void actionPerformed(final ActionEvent e) {
-				canceled = true;
-				ProgressDialog.this.dispose();
-			}
+		cancel.addActionListener(e -> {
+			canceled = true;
+			ProgressDialog.this.dispose();
 		});
 		buttons.add(cancel);
 		buttons.setMaximumSize(buttons.getMinimumSize());
@@ -171,13 +159,10 @@ public class ProgressDialog extends JDialog implements Progress {
 
 	protected void setTitle() {
 		checkIfCanceled();
-		SwingTools.invokeOnEDT(new Runnable() {
-			@Override
-			public void run() {
-				if (detailsScrollPane.isVisible() || latestDetail == null) progress
-					.setString(title);
-				else progress.setString(title + ": " + latestDetail.getString());
-			}
+		SwingTools.invokeOnEDT(() -> {
+			if (detailsScrollPane.isVisible() || latestDetail == null) progress
+				.setString(title);
+			else progress.setString(title + ": " + latestDetail.getString());
 		});
 		repaint();
 	}
@@ -186,12 +171,9 @@ public class ProgressDialog extends JDialog implements Progress {
 	public void setCount(final int count, final int total) {
 		checkIfCanceled();
 		if (updatesTooFast()) return;
-		SwingTools.invokeOnEDT(new Runnable() {
-			@Override
-			public void run() {
-				progress.setMaximum(total);
-				progress.setValue(count);
-			}
+		SwingTools.invokeOnEDT(() -> {
+			progress.setMaximum(total);
+			progress.setValue(count);
 		});
 		repaint();
 	}
@@ -210,13 +192,10 @@ public class ProgressDialog extends JDialog implements Progress {
 	public void setItemCount(final int count, final int total) {
 		checkIfCanceled();
 		if (itemUpdatesTooFast()) return;
-		SwingTools.invokeOnEDT(new Runnable() {
-			@Override
-			public void run() {
-				latestDetail.setMaximum(total);
-				latestDetail.setValue(count);
-				repaint();
-			}
+		SwingTools.invokeOnEDT(() -> {
+			latestDetail.setMaximum(total);
+			latestDetail.setValue(count);
+			repaint();
 		});
 	}
 
@@ -224,41 +203,30 @@ public class ProgressDialog extends JDialog implements Progress {
 	public void itemDone(final Object item) {
 		checkIfCanceled();
 		if (itemUpdatesTooFast() && !detailsScrollPane.isVisible()) return;
-		SwingTools.invokeOnEDT(new Runnable() {
-			@Override
-			public void run() {
-				latestDetail.setValue(latestDetail.getMaximum());
-			}
-		});
+		SwingTools.invokeOnEDT(() -> latestDetail.setValue(latestDetail.getMaximum()));
 	}
 
 	@Override
 	public void done() {
 		if (latestDetail != null) latestDetail.setValue(latestDetail.getMaximum());
-		SwingTools.invokeOnEDT(new Runnable() {
-			@Override
-			public void run() {
-				progress.setValue(progress.getMaximum());
-				dispose();
-			}
+		SwingTools.invokeOnEDT(() -> {
+			progress.setValue(progress.getMaximum());
+			dispose();
 		});
 	}
 
 	public void toggleDetails() {
-		SwingTools.invokeOnEDT(new Runnable() {
-			@Override
-			public void run() {
-				final boolean show = !detailsScrollPane.isVisible();
-				detailsScrollPane.setVisible(show);
-				detailsScrollPane.invalidate();
-				detailsToggle.setText(show ? "Hide Details" : "Show Details");
-				setTitle();
+		SwingTools.invokeOnEDT(() -> {
+			final boolean show = !detailsScrollPane.isVisible();
+			detailsScrollPane.setVisible(show);
+			detailsScrollPane.invalidate();
+			detailsToggle.setText(show ? "Hide Details" : "Show Details");
+			setTitle();
 
-				final Dimension dimension = getSize();
-				if (toggleHeight == -1) toggleHeight = dimension.height + 100;
-				setSize(new Dimension(dimension.width, toggleHeight));
-				toggleHeight = dimension.height;
-			}
+			final Dimension dimension = getSize();
+			if (toggleHeight == -1) toggleHeight = dimension.height + 100;
+			setSize(new Dimension(dimension.width, toggleHeight));
+			toggleHeight = dimension.height;
 		});
 	}
 

--- a/src/main/java/net/imagej/ui/swing/updater/ResolveDependencies.java
+++ b/src/main/java/net/imagej/ui/swing/updater/ResolveDependencies.java
@@ -55,7 +55,7 @@ public class ResolveDependencies extends ConflictDialog {
 	public ResolveDependencies(final UpdaterFrame owner,
 		final FilesCollection files, final boolean forUpload)
 	{
-		super(owner, "Resolve dependencies");
+		super(owner, "Resolve Dependencies");
 
 		this.forUpload = forUpload;
 		conflicts = new Conflicts(files);

--- a/src/main/java/net/imagej/ui/swing/updater/ReviewSiteURLsDialog.java
+++ b/src/main/java/net/imagej/ui/swing/updater/ReviewSiteURLsDialog.java
@@ -80,30 +80,31 @@ public class ReviewSiteURLsDialog extends JDialog implements ActionListener {
 	 */
 	public ReviewSiteURLsDialog(final UpdaterFrame owner, final List< URLChange > urlChanges)
 	{
-		super(owner, "Changes to available update sites", ModalityType.DOCUMENT_MODAL);
+		super(owner, "Changes to Available Update Sites", ModalityType.DOCUMENT_MODAL);
 
 		this.urlChanges = urlChanges;
 
-		final Container contentPane = getContentPane();
+		final JPanel contentPane = new JPanel();
 		contentPane.setLayout(new MigLayout("fill, gap 0"));
 
 		this.urlChanges.forEach( change -> change.setApproved(change.isRecommended()));
 
 		if( this.urlChanges.size() > 0) {
-			setMinimumSize(new Dimension(900, 0));
+			//setMinimumSize(new Dimension(900, 0));
 			contentPane.add(createHeader(), "span, grow");
 			contentPane.add(createUpdateSiteScrollPane(), "newline, span, grow, push");
 			contentPane.add(createButtonsPanel(), "dock south");
 			updateGeneralChoices();
 		} else {
-			setMinimumSize(new Dimension(0, 0));
+			//setMinimumSize(new Dimension(0, 0));
 			contentPane.add(createOkPanel(), "dock south");
-			contentPane.add(createOkIcon(), "w 70px!");
+			contentPane.add(createOkIcon());
 			contentPane.add(createEverythingIsFineMessage());
 		}
 
 		escapeCancels(this);
 		setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+		setContentPane(contentPane);
 		pack();
 		setLocationRelativeTo(owner);
 	}
@@ -122,17 +123,17 @@ public class ReviewSiteURLsDialog extends JDialog implements ActionListener {
 	}
 
 	private Component createEverythingIsFineMessage() {
-		JEditorPane text = createHTMLText("<html><h2>Software package sources up to date</h2>" +
+		JEditorPane text = createHTMLText("<html><h3>Software package sources up to date</h3>" +
 				"No updated URLs found for activated update sites.</html>");
 		text.setBorder(BorderFactory.createEmptyBorder(10, 10, 20, 25));
-		text.setMinimumSize(new Dimension(0,0));
+		//text.setMinimumSize(new Dimension(0,0));
 		return text;
 	}
 
 	private Component createOkPanel() {
 		JPanel panel = new JPanel();
 		ok = new JButton("OK");
-		panel.setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, Color.darkGray));
+		//panel.setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, Color.darkGray));
 		panel.add(ok);
 		ok.addActionListener(this);
 		getRootPane().setDefaultButton(ok);
@@ -159,15 +160,16 @@ public class ReviewSiteURLsDialog extends JDialog implements ActionListener {
 	}
 
 	private static Component createOkIcon() {
-		JLabel label = new JLabel(":-)", SwingConstants.CENTER);
-		label.setFont(new Font(label.getFont().getName(), Font.BOLD, 32));
-		label.setForeground(new Color(114, 200, 218));
+		JLabel label = new JLabel("<html><h2>:-)</h2>", SwingConstants.CENTER);
+		label.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+		//label.setFont(new Font(label.getFont().getName(), Font.BOLD, (int) (label.getFont().getSize() * 2.5)));
+		//label.setForeground(new Color(114, 200, 218));
 		return label;
 //		return new JLabel(javax.swing.UIManager.getIcon("OptionPane.informationIcon"));
 	}
 
 	private static Component createUpdatesAvailableMessage() {
-		return createHTMLText("<html><h2>Updated software package sources</h2>" +
+		return createHTMLText("<html><h3>Updated software package sources</h3>" +
 				"<p>Please review the following update site URL changes.<br/>" +
 				"If you have never heard of update sites," +
 				" just click <b>OK</b> at the bottom.</p></html>");
@@ -176,14 +178,14 @@ public class ReviewSiteURLsDialog extends JDialog implements ActionListener {
 	private static Component createHTTPSInfo() {
 		// TODO remove note in Updater V2
 		JEditorPane text = createHTMLText("<html><h3>ImageJ is improving<br/>data security!</h3>" +
-				"From now on ImageJ is supposed to update more securely via HTTPS. " +
+				"From now on ImageJ updates more securely via HTTPS. " +
 				"Therefore addresses of update sites currently in use by your ImageJ installation " +
 				"need to be updated.</html>");
-		text.setBackground(new Color(250,250,250));
-		text.setBorder(BorderFactory.createEmptyBorder(25,15,25,25));
-		String bodyRule = "body { color: #404042; }";
-		((HTMLDocument)text.getDocument()).getStyleSheet().addRule(bodyRule);
-		text.setOpaque(true);
+		//text.setBackground(new Color(250,250,250));
+		//text.setBorder(BorderFactory.createEmptyBorder(25,15,25,25));
+		//String bodyRule = "body { color: #404042; }";
+		//((HTMLDocument)text.getDocument()).getStyleSheet().addRule(bodyRule);
+		//text.setOpaque(true);
 		return text;
 	}
 
@@ -233,7 +235,7 @@ public class ReviewSiteURLsDialog extends JDialog implements ActionListener {
 	private Component createUpdateSiteScrollPane() {
 		JScrollPane scrollPane = new JScrollPane(createUpdatableSitesTable());
 		scrollPane.setPreferredSize(new Dimension(tableModel.tableWidth, 150));
-		scrollPane.setMinimumSize(new Dimension(0,0));
+		//scrollPane.setMinimumSize(new Dimension(0,0));
 		return scrollPane;
 	}
 

--- a/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
+++ b/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
@@ -328,11 +328,11 @@ public class SitesDialog extends JDialog implements ActionListener {
 			}
 		});
 
-		addNewSite = SwingTools.button("Add update site", "Add a new/unlisted update site", this, buttons);
-		remove = SwingTools.button("Remove", "Remove selected update site(s)", this, buttons);
+		addNewSite = SwingTools.button("Add Unlisted Site", "Add a new entry for a site not listed", this, buttons);
+		remove = SwingTools.button("Remove", "Remove highlighted site from list", this, buttons);
 		remove.setEnabled(false);
 		checkForUpdates = SwingTools.button("Validate URLs", "Check whether update sites are using outdated URLs", this, buttons);
-		close = SwingTools.button("Close", "Dismiss this window [ESC]", this, buttons);
+		close = SwingTools.button("Apply and Close", "Confirm subscriptions and dismiss [ESC]", this, buttons);
 
 		getRootPane().setDefaultButton(close);
 		escapeCancels(this);
@@ -379,6 +379,8 @@ public class SitesDialog extends JDialog implements ActionListener {
 	}
 
 	private void addNew() {
+		searchTerm.setText(""); // Reset table or a row index out of range is triggered
+		table.requestFocusInWindow();
 		add(new UpdateSite(makeUniqueSiteName("New"), "", "", "", null, null, 0l));
 
 		table.changeSelection( table.getRowCount()-1, 2, false, false);

--- a/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
+++ b/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
@@ -125,7 +125,7 @@ public class SitesDialog extends JDialog implements ActionListener {
 			@Override
 			public void valueChanged(final ListSelectionEvent e) {
 				super.valueChanged(e);
-				remove.setEnabled(getSelectedRow() > 0);
+				remove.setEnabled(!getSelectionModel().isSelectionEmpty());
 			}
 
 			@Override
@@ -438,16 +438,26 @@ public class SitesDialog extends JDialog implements ActionListener {
 			+ "</p></html>";
 	}
 
+	/*
+	 * returns the name of the update site associated with the _viewed_ row by
+	 * mapping its index to the table model
+	 */
 	protected String getUpdateSiteName(int row) {
-		return sites.get(row).getName();
+		return getUpdateSite(row).getName();
 	}
 
+	/*
+	 * returns the update site associated with the _viewed_ row by mapping its index
+	 * to the table model
+	 */
 	protected UpdateSite getUpdateSite(int row) {
-		return sites.get(row);
+		// table model does not change but the table _display_ does change during
+		// filtering so we need to look up the proper index of displayed rows
+		return sites.get(table.convertRowIndexToModel(row));
 	}
 
 	private void addNew() {
-		searchTerm.setText(""); // Reset table or a row index out of range is triggered
+		searchTerm.setText(""); // Reset filtering so that displayed rows match row model
 		table.requestFocusInWindow();
 		add(new UpdateSite(makeUniqueSiteName("New"), "", "", "", null, null, 0l));
 
@@ -526,6 +536,7 @@ public class SitesDialog extends JDialog implements ActionListener {
 				e.printStackTrace();
 			}
 			if(changesApproved.get()) {
+				searchTerm.setText(""); // Reset filtering
 				AvailableSites.applySitesURLUpdates(files, changes);
 			}
 			tableModel.rowsChanged(0, tableModel.getRowCount()-1);
@@ -593,8 +604,8 @@ public class SitesDialog extends JDialog implements ActionListener {
 
 		@Override
 		public Object getValueAt(final int row, final int col) {
-			if (col == 1) return getUpdateSiteName(row);
-			final UpdateSite site = getUpdateSite(row);
+			if (col == 1) return sites.get(row).getName();
+			final UpdateSite site = sites.get(row);
 			if (col == 0) return Boolean.valueOf(site.isActive());
 			if (col == 2) return site.getURL();
 			if (col == 3) return site.getHost();

--- a/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
+++ b/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
@@ -326,7 +326,7 @@ public class SitesDialog extends JDialog implements ActionListener {
 
 		// Adjust table size, column widths and scrollbars
 		tableModel.setColumnWidths();
-		scrollpane.setPreferredSize(new Dimension(tableModel.tableWidth, 500));
+		scrollpane.setPreferredSize(new Dimension(tableModel.tableWidth, 12 * table.getRowHeight()));
 		contentPane.addComponentListener(new ComponentAdapter() {
 			@Override
 			public void componentResized(final ComponentEvent e) {
@@ -343,7 +343,7 @@ public class SitesDialog extends JDialog implements ActionListener {
 		remove = SwingTools.button("Remove", "Remove highlighted site from list", this, buttons);
 		remove.setEnabled(false);
 		checkForUpdates = SwingTools.button("Validate URLs", "Check whether update sites are using outdated URLs", this, buttons);
-		close = SwingTools.button("Apply and Close", "Confirm subscriptions and dismiss [ESC]", this, buttons);
+		close = SwingTools.button("Apply and Close", "Confirm activations and dismiss [ESC]", this, buttons);
 
 		getRootPane().setDefaultButton(close);
 		escapeCancels(this);
@@ -565,7 +565,6 @@ public class SitesDialog extends JDialog implements ActionListener {
 	protected class DataModel extends DefaultTableModel {
 
 		protected int tableWidth;
-		protected int[] minWidths = { 20, 380, 280, 125, 125, 500 };
 		protected String[] headers = { "Active", "Name", "URL", "Host", "Directory on Host", "Description" };
 		private String[] canonicalRows = { "Active", "Fuzzy logic and artificial neural",
 				"sites.imagej.net/Fiji-Legacy/", "webdav:User", "/path", " Large description with maintainer name" };
@@ -574,10 +573,9 @@ public class SitesDialog extends JDialog implements ActionListener {
 			table.setAutoResizeMode(JTable.AUTO_RESIZE_OFF); // otherwise horizontal scrollbar is not displayed
 			final TableColumnModel columnModel = table.getColumnModel();
 			final FontMetrics fm = table.getFontMetrics(table.getFont());
-			for (int i = 0; i < tableModel.minWidths.length && i < getColumnCount(); i++) {
+			for (int i = 0; i < tableModel.headers.length && i < getColumnCount(); i++) {
 				final TableColumn column = columnModel.getColumn(i);
 				column.setPreferredWidth(fm.stringWidth(canonicalRows[i]));
-				column.setMinWidth(tableModel.minWidths[i]);
 				tableWidth += column.getPreferredWidth();
 			}
 		}

--- a/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
+++ b/src/main/java/net/imagej/ui/swing/updater/SitesDialog.java
@@ -33,6 +33,8 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.FontMetrics;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ComponentAdapter;
@@ -47,7 +49,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.swing.AbstractAction;
-import javax.swing.BoxLayout;
 import javax.swing.DefaultCellEditor;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -104,14 +105,14 @@ public class SitesDialog extends JDialog implements ActionListener {
 
 	public SitesDialog(final UpdaterFrame owner, final FilesCollection files)
 	{
-		super(owner, "Manage update sites");
+		super(owner, "Manage Update Sites");
 		updaterFrame = owner;
 		this.files = files;
 
 		sites = new ArrayList<>(files.getUpdateSites(true));
 
 		final Container contentPane = getContentPane();
-		contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.PAGE_AXIS));
+		contentPane.setLayout(new GridBagLayout());
 
 		tableModel = new DataModel();
 		table = new JTable(tableModel) {
@@ -292,13 +293,27 @@ public class SitesDialog extends JDialog implements ActionListener {
 				filterTable();
 			}
 		});
-		final JPanel searchPanel = SwingTools.labelComponentRigid("Search:", searchTerm);
-		contentPane.add(searchPanel);
 
-		// Adjust table size, column widths and scrollbars
+		// Add all components to dialog
+		final JPanel searchPanel = SwingTools.labelComponentRigid("Search:", searchTerm);
 		scrollpane = new JScrollPane(table, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
 				JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
-		contentPane.add(scrollpane);
+		final JPanel buttons = new JPanel();
+		final GridBagConstraints c = new GridBagConstraints();
+		c.gridx = 0;
+		c.gridy = 0;
+		c.weightx = 1;
+		c.fill = GridBagConstraints.BOTH;
+		c.weighty = 0;
+		contentPane.add(searchPanel, c);
+		c.gridy++;
+		c.weighty = 1;
+		contentPane.add(scrollpane, c);
+		c.gridy++;
+		c.weighty = 0;
+		contentPane.add(buttons, c);
+
+		// Adjust table size, column widths and scrollbars
 		tableModel.setColumnWidths();
 		scrollpane.setPreferredSize(new Dimension(tableModel.tableWidth, 500));
 		contentPane.addComponentListener(new ComponentAdapter() {
@@ -313,13 +328,11 @@ public class SitesDialog extends JDialog implements ActionListener {
 			}
 		});
 
-		final JPanel buttons = new JPanel();
-		addNewSite = SwingTools.button("Add update site", "Add your own update site", this, buttons);
+		addNewSite = SwingTools.button("Add update site", "Add a new/unlisted update site", this, buttons);
 		remove = SwingTools.button("Remove", "Remove selected update site(s)", this, buttons);
 		remove.setEnabled(false);
-		checkForUpdates = SwingTools.button("Update URLs", "Check whether update sites are using outdated URLs", this, buttons);
-		close = SwingTools.button("Close", "Dismiss this window", this, buttons);
-		contentPane.add(buttons);
+		checkForUpdates = SwingTools.button("Validate URLs", "Check whether update sites are using outdated URLs", this, buttons);
+		close = SwingTools.button("Close", "Dismiss this window [ESC]", this, buttons);
 
 		getRootPane().setDefaultButton(close);
 		escapeCancels(this);
@@ -473,8 +486,8 @@ public class SitesDialog extends JDialog implements ActionListener {
 		protected int tableWidth;
 		protected int[] minWidths = { 20, 380, 280, 125, 125, 500 };
 		protected String[] headers = { "Active", "Name", "URL", "Host", "Directory on Host", "Description" };
-		protected String[] canonicalRows = { "", "Fuzzy logic and artificial neural",
-				"sites.imagej.net/Fiji-Legacy/", "webdav:User", "/path", " Large description with maintainer name"};
+		private String[] canonicalRows = { "Active", "Fuzzy logic and artificial neural",
+				"sites.imagej.net/Fiji-Legacy/", "webdav:User", "/path", " Large description with maintainer name" };
 
 		public void setColumnWidths() {
 			table.setAutoResizeMode(JTable.AUTO_RESIZE_OFF); // otherwise horizontal scrollbar is not displayed

--- a/src/main/java/net/imagej/ui/swing/updater/SwingTools.java
+++ b/src/main/java/net/imagej/ui/swing/updater/SwingTools.java
@@ -57,6 +57,7 @@ import javax.swing.JTextPane;
 import javax.swing.KeyStroke;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.event.DocumentListener;
 
 /**
@@ -87,7 +88,8 @@ public class SwingTools {
 	{
 		final JScrollPane scroll = new JScrollPane(component);
 		scroll.getViewport().setBackground(component.getBackground());
-		scroll.setPreferredSize(new Dimension(width, height));
+		if (width > -1 && height > -1)
+			scroll.setPreferredSize(new Dimension(width, height));
 		if (addTo != null) addTo.add(scroll);
 		return scroll;
 	}
@@ -231,14 +233,11 @@ public class SwingTools {
 	public static void showMessageBox(final Component owner,
 		final String message, final int type)
 	{
-		SwingTools.invokeOnEDT(new Runnable() {
-			@Override
-			public void run() {
-				final String title =
-					type == JOptionPane.ERROR_MESSAGE ? "Error"
-						: type == JOptionPane.WARNING_MESSAGE ? "Warning" : "Information";
-				JOptionPane.showMessageDialog(owner, message, title, type);
-			}
+		SwingTools.invokeOnEDT(() -> {
+			final String title =
+				type == JOptionPane.ERROR_MESSAGE ? "Error"
+					: type == JOptionPane.WARNING_MESSAGE ? "Warning" : "Information";
+			JOptionPane.showMessageDialog(owner, message, title, type);
 		});
 	}
 
@@ -275,6 +274,14 @@ public class SwingTools {
 			}
 		}
 		catch (final InterruptedException e) { /* ignore */}
+	}
+
+	public static int defaultFontSize() {
+		try {
+			return UIManager.getDefaults().getFont("TextPane.font").getSize();
+		} catch (final NullPointerException ignored) {
+			return 12;
+		}
 	}
 
 	public static void invokeOnEDT(final Runnable job) {

--- a/src/main/java/net/imagej/ui/swing/updater/UpdaterFrame.java
+++ b/src/main/java/net/imagej/ui/swing/updater/UpdaterFrame.java
@@ -437,8 +437,9 @@ public class UpdaterFrame extends JFrame implements TableModelListener,
 	public UploaderService getUploaderService() {
 		if (uploaderService == null) {
 			setClassLoaderIfNecessary();
-			final Context context = new Context(UploaderService.class);
-			uploaderService = context.getService(UploaderService.class);
+			try (Context context = new Context(UploaderService.class)) {
+				uploaderService = context.getService(UploaderService.class);
+			}
 		}
 
 		return uploaderService;

--- a/src/main/java/net/imagej/ui/swing/updater/UpdaterFrame.java
+++ b/src/main/java/net/imagej/ui/swing/updater/UpdaterFrame.java
@@ -58,11 +58,14 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTabbedPane;
 import javax.swing.JTextField;
 import javax.swing.RowSorter.SortKey;
 import javax.swing.SortOrder;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
+import javax.swing.border.Border;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.event.ListSelectionEvent;
@@ -90,7 +93,6 @@ import net.imagej.updater.util.UpdaterUtil;
 
 import org.scijava.Context;
 import org.scijava.log.LogService;
-import org.scijava.util.ProcessUtils;
 
 /**
  * TODO
@@ -114,25 +116,32 @@ public class UpdaterFrame extends JFrame implements TableModelListener,
 	protected FileTable table;
 	protected JLabel fileSummary;
 	protected JPanel summaryPanel;
-	protected JPanel rightPanel;
 	protected FileDetails fileDetails;
-	protected JPanel bottomPanel, bottomPanel2;
-	protected JButton applyOrUpload, cancel, easy, updateSites;
+	protected JPanel bottomPanel, easyBottomPanel;
+	protected JButton applyOrUpload, cancel, easy, easy2, updateSites;
 	protected boolean easyMode;
 
 	// For developers
 	protected JButton showChanges, rebuildButton;
 	protected boolean canUpload;
+	private CollapsibleLeftRightSplitPane splitPane;
 
 	public UpdaterFrame(final LogService log,
 		final UploaderService uploaderService, final FilesCollection files)
 	{
 		super("ImageJ Updater");
-		setPreferredSize(new Dimension(780, 560));
+		//setPreferredSize(new Dimension((easyMode) ? 700 : 900, 560));
 
 		this.log = log;
 		this.uploaderService = uploaderService;
 		this.files = files;
+
+		// make sure that sezpoz finds the classes when triggered from the EDT
+		final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+		SwingTools.invokeOnEDT(() -> {
+			if (contextClassLoader != null)
+				Thread.currentThread().setContextClassLoader(contextClassLoader);
+		});
 
 		setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
 		addWindowListener(new WindowAdapter() {
@@ -145,14 +154,9 @@ public class UpdaterFrame extends JFrame implements TableModelListener,
 
 		// ======== Start: LEFT PANEL ========
 		final JPanel leftPanel = new JPanel();
-		final GridBagLayout gb = new GridBagLayout();
+		GridBagLayout gb = new GridBagLayout();
 		leftPanel.setLayout(gb);
-		final GridBagConstraints c = new GridBagConstraints(0, 0, // x, y
-			9, 1, // rows, cols
-			0, 0, // weightx, weighty
-			GridBagConstraints.NORTHWEST, // anchor
-			GridBagConstraints.HORIZONTAL, // fill
-			new Insets(0, 0, 0, 0), 0, 0); // ipadx, ipady
+		GridBagConstraints c = Utils.gbConstraints();
 
 		searchTerm = new JTextField();
 		searchTerm.getDocument().addDocumentListener(new DocumentListener() {
@@ -176,19 +180,13 @@ public class UpdaterFrame extends JFrame implements TableModelListener,
 		gb.setConstraints(searchPanel, c);
 		leftPanel.add(searchPanel);
 
-		Component box = Box.createRigidArea(new Dimension(0, 10));
+		Component box = Utils.vSpace();
 		c.gridy = 1;
 		gb.setConstraints(box, c);
 		leftPanel.add(box);
 
 		viewOptions = new ViewOptions();
-		viewOptions.addActionListener(new ActionListener() {
-
-			@Override
-			public void actionPerformed(final ActionEvent e) {
-				updateFilesTable();
-			}
-		});
+		viewOptions.addActionListener(e -> updateFilesTable());
 
 		viewOptionsPanel =
 			SwingTools.labelComponentRigid("View Options:", viewOptions);
@@ -196,7 +194,7 @@ public class UpdaterFrame extends JFrame implements TableModelListener,
 		gb.setConstraints(viewOptionsPanel, c);
 		leftPanel.add(viewOptionsPanel);
 
-		box = Box.createRigidArea(new Dimension(0, 10));
+		box = Utils.vSpace();
 		c.gridy = 3;
 		gb.setConstraints(box, c);
 		leftPanel.add(box);
@@ -209,7 +207,7 @@ public class UpdaterFrame extends JFrame implements TableModelListener,
 		gb.setConstraints(chooseLabel, c);
 		leftPanel.add(chooseLabel);
 
-		box = Box.createRigidArea(new Dimension(0, 5));
+		box = Utils.vSpace();
 		c.gridy = 5;
 		gb.setConstraints(box, c);
 		leftPanel.add(box);
@@ -217,6 +215,7 @@ public class UpdaterFrame extends JFrame implements TableModelListener,
 		// Label text for file summaries
 		fileSummary = new JLabel();
 		summaryPanel = SwingTools.horizontalPanel();
+		summaryPanel.add(Utils.hSpace());
 		summaryPanel.add(fileSummary);
 		summaryPanel.add(Box.createHorizontalGlue());
 
@@ -233,150 +232,145 @@ public class UpdaterFrame extends JFrame implements TableModelListener,
 		gb.setConstraints(fileListScrollpane, c);
 		leftPanel.add(fileListScrollpane);
 
-		box = Box.createRigidArea(new Dimension(0, 5));
+		box = Utils.vSpace();
 		c.gridy = 7;
 		c.weightx = 0;
 		c.weighty = 0;
 		c.fill = GridBagConstraints.HORIZONTAL;
 		gb.setConstraints(box, c);
 		leftPanel.add(box);
-
 		// ======== End: LEFT PANEL ========
 
 		// ======== Start: RIGHT PANEL ========
-		rightPanel = SwingTools.verticalPanel();
+		final JPanel rightPanel = new JPanel();
+		gb = new GridBagLayout();
+		rightPanel.setLayout(gb);
+		c = Utils.gbConstraints();
 
-		rightPanel.add(Box.createVerticalGlue());
+		updateSites = manageButton();
+		c.fill = GridBagConstraints.NONE;
+		c.anchor = GridBagConstraints.NORTHEAST;
+		gb.setConstraints(updateSites, c);
+		rightPanel.add(updateSites);
+
+		box = Utils.vSpace();
+		c.gridy = 1;
+		gb.setConstraints(box, c);
+		rightPanel.add(box);
+
+		easy = easyButton();
+		Utils.equalizeDimensions(easy, updateSites);
+		c.gridy = 2;
+		gb.setConstraints(easy, c);
+		rightPanel.add(easy);
+
+		box = Utils.vSpace();
+		c.gridy = 3;
+		gb.setConstraints(box, c);
+		rightPanel.add(box);
+
+		final JPanel dummyLabel = SwingTools.label("", null);
+		c.gridy = 4;
+		gb.setConstraints(dummyLabel, c);
+		rightPanel.add(dummyLabel);
+
+		box = Utils.vSpace();
+		c.gridy = 5;
+		gb.setConstraints(box, c);
+		rightPanel.add(box);
 
 		fileDetails = new FileDetails(this);
-		SwingTools.tab(fileDetails, "Details", "Individual file information", 350,
-			315, rightPanel);
-		// TODO: put this into SwingTools, too
-		rightPanel.add(Box.createRigidArea(new Dimension(0, 25)));
+		fileDetails.setBackground(table.getBackground());
+		JTabbedPane tabbedPane = new JTabbedPane();
+		tabbedPane.addTab("Details", null, SwingTools.scrollPane(fileDetails, -1, -1, null),
+				"Individual file information");
+
+		c.gridy = 6;
+		c.weightx = 1;
+		c.weighty = 1;
+		c.anchor = GridBagConstraints.NORTHWEST;
+		c.fill = GridBagConstraints.BOTH;
+		gb.setConstraints(tabbedPane, c);
+		rightPanel.add(tabbedPane);
+
+		box = Utils.vSpace();
+		c.gridy = 7;
+		c.weightx = 0;
+		c.weighty = 0;
+		c.fill = GridBagConstraints.HORIZONTAL;
+		gb.setConstraints(box, c);
+		rightPanel.add(box);
+//		rightPanel.setMaximumSize(new Dimension((int) (leftPanel.getPreferredSize().getWidth() * .25),
+//				rightPanel.getMaximumSize().height));
 		// ======== End: RIGHT PANEL ========
 
 		// ======== Start: TOP PANEL (LEFT + RIGHT) ========
+		splitPane = new CollapsibleLeftRightSplitPane(leftPanel, rightPanel);
 		final JPanel topPanel = SwingTools.horizontalPanel();
-		topPanel.add(leftPanel);
-		topPanel.add(Box.createRigidArea(new Dimension(15, 0)));
-		topPanel.add(rightPanel);
-		topPanel.setBorder(BorderFactory.createEmptyBorder(20, 15, 5, 15));
+		topPanel.add(splitPane);
+		topPanel.setBorder(Utils.defaultBorder());
 		// ======== End: TOP PANEL (LEFT + RIGHT) ========
 
-		bottomPanel2 = SwingTools.horizontalPanel();
+		easyBottomPanel = SwingTools.horizontalPanel();
+		easyBottomPanel.add(manageButton());
+		easyBottomPanel.add(Utils.hSpace());
+		easyBottomPanel.add(easy2 = easyButton());
+		easyBottomPanel.add(Utils.hSpace());
+		easyBottomPanel.setVisible(easyMode);
+
 		bottomPanel = SwingTools.horizontalPanel();
-		bottomPanel.setBorder(BorderFactory.createEmptyBorder(5, 15, 15, 15));
+		bottomPanel.setBorder(Utils.defaultBorder());
+		bottomPanel.add(easyBottomPanel);
 		bottomPanel.add(new FileActionButton(new KeepAsIs()));
-		bottomPanel.add(Box.createRigidArea(new Dimension(15, 0)));
+		bottomPanel.add(Utils.hSpace());
 		bottomPanel.add(new FileActionButton(new InstallOrUpdate()));
-		bottomPanel.add(Box.createRigidArea(new Dimension(15, 0)));
+		bottomPanel.add(Utils.hSpace());
 		bottomPanel.add(new FileActionButton(new Uninstall()));
+		bottomPanel.add(Utils.hSpace());
+		showChanges =
+				SwingTools.button("Diff",
+					"Show the differences to the uploaded version", e -> new Thread() {
 
+						@Override
+						public void run() {
+							for (final FileObject file : table.getSelectedFiles()) try {
+								final DiffFile diff = new DiffFile(files, file, Mode.LIST_FILES);
+								diff.setLocationRelativeTo(UpdaterFrame.this);
+								diff.setVisible(true);
+							} catch (MalformedURLException e) {
+								files.log.error(e);
+								UpdaterUserInterface.get().error("There was a problem obtaining the remote version of " + file.getLocalFilename(true));
+							}
+						}
+					}.start(), bottomPanel);
 		bottomPanel.add(Box.createHorizontalGlue());
-
-		// make sure that sezpoz finds the classes when triggered from the EDT
-		final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-		SwingTools.invokeOnEDT(new Runnable() {
-			@Override
-			public void run() {
-				if (contextClassLoader != null)
-					Thread.currentThread().setContextClassLoader(contextClassLoader);
-			}
-		});
-
 		// Button to start actions
 		applyOrUpload =
-			SwingTools.button("Apply changes", "Start installing/uninstalling/uploading files",
-				new ActionListener() {
-
-					@Override
-					public void actionPerformed(final ActionEvent e) {
-						if (files.hasUploadOrRemove()) {
-							new Thread() {
-
-								@Override
-								public void run() {
-									try {
-										upload();
-									}
-									catch (final InstantiationException e) {
-										log.error(e);
-										error("Could not upload (possibly unknown protocol)");
-									}
-								}
-							}.start();
-						}
-						else if (files.hasChanges()) {
-							applyChanges();
-						}
-					}
-				}, bottomPanel);
-		enableApplyOrUpload();
-
-		// Manage update sites
-		updateSites =
-			SwingTools.button("Manage update sites",
-				"Manage multiple update sites for updating and uploading",
-				new ActionListener() {
-
-					@Override
-					public void actionPerformed(final ActionEvent e) {
-						new SitesDialog(UpdaterFrame.this, UpdaterFrame.this.files).setVisible(true);
-					}
-				}, bottomPanel2);
-
-		// TODO: unify upload & apply changes (probably apply changes first, then
-		// upload)
-		// includes button to upload to server if is a Developer using
-		bottomPanel2.add(Box.createRigidArea(new Dimension(15, 0)));
-
-		bottomPanel2.add(Box.createRigidArea(new Dimension(15, 0)));
-		showChanges =
-			SwingTools.button("Show changes",
-				"Show the differences to the uploaded version", new ActionListener()
-				{
-
-					@Override
-					public void actionPerformed(final ActionEvent e) {
+			SwingTools.button("Apply Changes", "Start installing/uninstalling/uploading files",
+				e -> {
+					if (files.hasUploadOrRemove()) {
 						new Thread() {
 
 							@Override
 							public void run() {
-								for (final FileObject file : table.getSelectedFiles()) try {
-									final DiffFile diff = new DiffFile(files, file, Mode.LIST_FILES);
-									diff.setLocationRelativeTo(UpdaterFrame.this);
-									diff.setVisible(true);
-								} catch (MalformedURLException e) {
-									files.log.error(e);
-									UpdaterUserInterface.get().error("There was a problem obtaining the remote version of " + file.getLocalFilename(true));
+								try {
+									upload();
+								}
+								catch (final InstantiationException e) {
+									log.error(e);
+									error("Could not upload (possibly unknown protocol)");
 								}
 							}
 						}.start();
 					}
-				}, bottomPanel2);
-
-		bottomPanel2.add(Box.createHorizontalGlue());
-
-		bottomPanel.add(Box.createRigidArea(new Dimension(15, 0)));
-		easy =
-			SwingTools.button("Toggle easy mode",
-				"Toggle between easy and verbose mode", new ActionListener() {
-
-					@Override
-					public void actionPerformed(final ActionEvent e) {
-						toggleEasyMode();
+					else if (files.hasChanges()) {
+						applyChanges();
 					}
 				}, bottomPanel);
+		enableApplyOrUpload();
 
-		bottomPanel.add(Box.createRigidArea(new Dimension(15, 0)));
-		cancel =
-			SwingTools.button("Close", "Exit Update Manager", new ActionListener() {
-
-				@Override
-				public void actionPerformed(final ActionEvent e) {
-					quit();
-				}
-			}, bottomPanel);
+		bottomPanel.add(Utils.hSpace());
+		cancel = SwingTools.button("Close", "Exit Updater [Esc]", e -> quit(), bottomPanel);
 		// ======== End: BOTTOM PANEL ========
 
 		getContentPane().setLayout(
@@ -384,12 +378,9 @@ public class UpdaterFrame extends JFrame implements TableModelListener,
 		getContentPane().add(topPanel);
 		getContentPane().add(summaryPanel);
 		getContentPane().add(bottomPanel);
-		getContentPane().add(bottomPanel2);
 
 		getRootPane().setDefaultButton(applyOrUpload);
-
 		table.getModel().addTableModelListener(this);
-
 		pack();
 
 		SwingTools.addAccelerator(cancel, (JComponent) getContentPane(), cancel
@@ -400,15 +391,10 @@ public class UpdaterFrame extends JFrame implements TableModelListener,
 	public void setVisible(final boolean visible) {
 		if (!SwingUtilities.isEventDispatchThread()) {
 			try {
-				SwingUtilities.invokeAndWait(new Runnable() {
-					@Override
-					public void run() {
-						setVisible(visible);
-					}
-				});
-			} catch (InterruptedException e) {
+				SwingUtilities.invokeAndWait(() -> setVisible(visible));
+			} catch (final InterruptedException e) {
 				// ignore
-			} catch (InvocationTargetException e) {
+			} catch (final InvocationTargetException e) {
 				log.error(e);
 			}
 			return;
@@ -512,34 +498,28 @@ public class UpdaterFrame extends JFrame implements TableModelListener,
 	}
 
 	public void setViewOption(final ViewOptions.Option option) {
-		SwingTools.invokeOnEDT(new Runnable() {
-			@Override
-			public void run() {
-				viewOptions.setSelectedItem(option);
-				updateFilesTable();
-			}
+		SwingTools.invokeOnEDT(() -> {
+			viewOptions.setSelectedItem(option);
+			updateFilesTable();
 		});
 	}
 
 	public void updateFilesTable() {
-		SwingTools.invokeOnEDT(new Runnable() {
-			@Override
-			public void run() {
-				Iterable<FileObject> view = viewOptions.getView(table);
-				final Set<FileObject> selected = new HashSet<>();
-				for (final FileObject file : table.getSelectedFiles())
-					selected.add(file);
-				table.clearSelection();
+		SwingTools.invokeOnEDT(() -> {
+			Iterable<FileObject> view = viewOptions.getView(table);
+			final Set<FileObject> selected = new HashSet<>();
+			for (final FileObject file : table.getSelectedFiles())
+				selected.add(file);
+			table.clearSelection();
 
-				final String search = searchTerm.getText().trim();
-				if (!search.equals("")) view = FilesCollection.filter(search, view);
+			final String search = searchTerm.getText().trim();
+			if (!search.equals("")) view = FilesCollection.filter(search, view);
 
-				// Directly update the table for display
-				table.setFiles(view);
-				for (int i = 0; i < table.getRowCount(); i++)
-					if (selected.contains(table.getFile(i))) table.addRowSelectionInterval(i,
-						i);
-			}
+			// Directly update the table for display
+			table.setFiles(view);
+			for (int i = 0; i < table.getRowCount(); i++)
+				if (selected.contains(table.getFile(i))) table.addRowSelectionInterval(i,
+					i);
 		});
 	}
 
@@ -594,15 +574,14 @@ public class UpdaterFrame extends JFrame implements TableModelListener,
 		viewOptionsPanel.setVisible(!easyMode);
 		chooseLabel.setVisible(!easyMode);
 		summaryPanel.setVisible(!easyMode);
-		rightPanel.setVisible(!easyMode);
-		if (easyMode) bottomPanel.add(updateSites, 0);
-		else bottomPanel2.add(updateSites, 0);
-
+		splitPane.setRightPaneVisible(!easyMode);
+		easyBottomPanel.setVisible(easyMode);
 		final boolean uploadable = !easyMode && files.hasUploadableSites();
 		if (showChanges != null) showChanges.setVisible(!easyMode);
 		if (rebuildButton != null) rebuildButton.setVisible(uploadable);
 
-		easy.setText(easyMode ? "Advanced mode" : "Easy mode");
+		easy.setText(easyMode ? "Advanced Mode" : "Easy Mode");
+		easy2.setText(easyMode ? "Advanced Mode" : "Easy Mode");
 	}
 
 	public void toggleEasyMode() {
@@ -695,7 +674,7 @@ public class UpdaterFrame extends JFrame implements TableModelListener,
 		}
 		String text = "";
 		if (install > 0) text +=
-			" install/update: " + install + (implicated > 0 ? "+" + implicated : "") +
+			" Install/update: " + install + (implicated > 0 ? "+" + implicated : "") +
 				" (" + sizeToString(bytesToDownload) + ")";
 		if (uninstall > 0) text += " uninstall: " + uninstall;
 		if (files.hasUploadableSites() && upload > 0) text +=
@@ -750,10 +729,10 @@ public class UpdaterFrame extends JFrame implements TableModelListener,
 	void enableApplyOrUpload() {
 		if (files.hasUploadOrRemove()) {
 			applyOrUpload.setEnabled(true);
-			applyOrUpload.setText("Apply changes (upload)");
+			applyOrUpload.setText("Apply Changes (Upload)");
 		}
 		else {
-			applyOrUpload.setText("Apply changes");
+			applyOrUpload.setText("Apply Changes");
 			applyOrUpload.setEnabled(files.hasChanges());
 		}
 	}
@@ -856,4 +835,90 @@ public class UpdaterFrame extends JFrame implements TableModelListener,
 	public void info(final String message) {
 		SwingTools.showMessageBox(this, message, JOptionPane.INFORMATION_MESSAGE);
 	}
+
+	JButton easyButton() {
+		return SwingTools.button("Easy Mode", "Toggle between simplified and advanced view", e -> toggleEasyMode(),
+				null);
+	}
+
+	JButton manageButton() {
+		 return SwingTools.button("Manage Update Sites",
+					"Manage subscriptions of update sites for updating and uploading",
+					e -> new SitesDialog(UpdaterFrame.this, UpdaterFrame.this.files).setVisible(true), null);
+	}
+
+	private class CollapsibleLeftRightSplitPane extends JSplitPane {
+
+		static final double DEF_DIVIDER_LOCATION = .85d;
+		final int defDividerSize;
+		int lastVisibleDividerLocation;
+		private Dimension rightComponentPreferredSize;
+
+		CollapsibleLeftRightSplitPane(final Component leftComponent, final Component rightComponent) {
+			super(HORIZONTAL_SPLIT, leftComponent, rightComponent);
+			defDividerSize = getDividerSize();
+			setDividerLocation(DEF_DIVIDER_LOCATION);
+			lastVisibleDividerLocation = getDividerLocation();
+			setResizeWeight(.90); // right component should minimally change on resize
+		}
+
+		void setResizable(final boolean resizable) {
+			if (resizable) {
+				setDividerSize(defDividerSize);
+			} else {
+				setDividerSize(0);
+			}
+			setEnabled(resizable);
+			//((BasicSplitPaneUI) getUI()).getDivider().setEnabled(resizable);
+		}
+
+		void setRightPaneVisible(final boolean visible) {
+			if (visible) {
+				setDividerLocation(lastVisibleDividerLocation);
+				getRightComponent().setPreferredSize(rightComponentPreferredSize);
+			} else {
+				lastVisibleDividerLocation = getDividerLocation();
+				rightComponentPreferredSize = getRightComponent().getPreferredSize();
+				setDividerLocation(1d);
+				getRightComponent().setPreferredSize(new Dimension(0,0));
+			}
+			getRightComponent().setVisible(visible);
+			setResizable(visible);
+			if (isVisible()) pack();
+		}
+	}
+
+	private static class Utils {
+
+		static Border defaultBorder() {
+			return BorderFactory.createEmptyBorder(5, 10, 10, 5);
+		}
+
+		static Component hSpace() {
+			return Box.createRigidArea(new Dimension(10, 0));
+		}
+
+		static Component vSpace() {
+			return Box.createRigidArea(new Dimension(0, 5));
+		}
+
+		static GridBagConstraints gbConstraints() {
+			return new GridBagConstraints(//
+					0, 0, // x, y
+					9, 1, // rows, cols
+					0, 0, // weightx, weighty
+					GridBagConstraints.NORTHWEST, // anchor
+					GridBagConstraints.HORIZONTAL, // fill
+					new Insets(0, 0, 0, 0), // insets
+					0, 0 // ipadx, ipady
+			);
+		}
+
+		static void equalizeDimensions(final JComponent source, final JComponent target) {
+			source.setMinimumSize(target.getMinimumSize());
+			source.setPreferredSize(target.getPreferredSize());
+			source.setMaximumSize(target.getMaximumSize());
+		}
+	}
+
 }

--- a/src/main/java/net/imagej/ui/swing/widget/SwingDimSelectionWidget.java
+++ b/src/main/java/net/imagej/ui/swing/widget/SwingDimSelectionWidget.java
@@ -33,7 +33,6 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Graphics;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -152,14 +151,7 @@ public class SwingDimSelectionWidget extends SwingInputWidget<TypedAxis[]>
 			final JToggleButton button =
 				new DimensionSelectionToggleButton(m_typedAxi.type().getLabel());
 
-			button.addActionListener(new ActionListener() {
-
-				@Override
-				public void actionPerformed(final ActionEvent e) {
-					toogleButtonChanged(e);
-				}
-
-			});
+			button.addActionListener(e -> toogleButtonChanged(e));
 
 			m_dimLabelButtonList.add(button);
 			getComponent().add(button);


### PR DESCRIPTION
 - SitesDialog: Implement filter-as-you-type functionality for the update site list, similar to the current functionality in the main file list
- Misc fixes for things sabotaging FlatLaf and other improvements:
  - Fix hardwired colors, font sizes, and other dimensions (borders, column widths, etc.)
  - Misc improvements  (layout, borders, tooltips, etc.)
  - Fix inconsistencies in capitalization in prompts
  - Replace java 6 code with lambda expressions

