### PR TITLE
Clearer message when update requires restart

### DIFF
--- a/src/main/java/net/imagej/ui/swing/updater/ImageJUpdater.java
+++ b/src/main/java/net/imagej/ui/swing/updater/ImageJUpdater.java
@@ -99,9 +99,9 @@ public class ImageJUpdater implements UpdaterUI {
 
 		if (new File(appDir, "update").exists()) {
 			if (!UpdaterUserInterface.get().promptYesNo("It is suggested that you restart ImageJ, then continue the update.\n"
-					+ "Alternately, you can attempt to continue the upgrade without\n"
+					+ "Alternatively, you can attempt to continue the upgrade without\n"
 					+ "restarting, but ImageJ might crash.\n\n"
-					+ "Do you want to try it?",
+					+ "Do you want to continue anyway?",
 					"Restart required to finalize update"))
 				return;
 			try {


### PR DESCRIPTION
I had trouble figuring out which way the Yes and No buttons in this message work (and my bet was wrong), so here's an edit to hopefully make it clear.

![image](https://github.com/user-attachments/assets/465770fb-636b-4fb0-b061-22f15817e581)

It might be better if the default button exits the update rather than continue-despite-the-danger. Or if the message just instructs to restart, without giving the option to continue and having only OK as the button. But not knowing the background, I'm just suggesting a minimal edit for now. Feel free to replace with something better!